### PR TITLE
refinement: edge-tts neural voice + sequential thinking dots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,8 @@ voice/models/*.onnx.json
 # macOS/Linux teammates: regenerate from https://console.picovoice.ai for your platform.
 
 # Whisper model cache lives in ~/.cache/whisper (outside the repo)
+
+# ── Tool / IDE metadata — never commit ───────────────────────────────────────
+.superpowers/
+.claude/
+voice/preview_*.wav

--- a/launcher/renderer/index.html
+++ b/launcher/renderer/index.html
@@ -129,8 +129,7 @@
       font-style: italic;
       padding: 8px 4px;
     }
-    .thinking span { animation: blink 1.2s step-start infinite; }
-    @keyframes blink { 0%,100%{opacity:1} 50%{opacity:.3} }
+    /* dots are driven by JS setInterval — no CSS animation needed */
 
     /* ── Input bar ── */
     #input-bar {
@@ -247,6 +246,7 @@ const WS_URL   = 'ws://localhost:8000/ws';
 // ── State ─────────────────────────────────────────────────────────────────────
 let conversationId      = null;   // set after first turn or history load
 let pendingTurn         = null;   // DOM node for the "thinking…" indicator
+let thinkingInterval    = null;   // setInterval ID for the animated dots
 let pendingVoiceWrapper = null;   // .turn wrapper rendered immediately on voice transcript
 let socket              = null;
 
@@ -293,16 +293,26 @@ function renderTurn(turn) {
 function showThinking() {
   pendingTurn = document.createElement("div");
   pendingTurn.className = "thinking";
+
   const label = document.createTextNode("Charles is thinking");
   const dots  = document.createElement("span");
-  dots.textContent = "…";
+  dots.textContent = ".";
+
   pendingTurn.appendChild(label);
   pendingTurn.appendChild(dots);
   $messages.appendChild(pendingTurn);
   scrollToBottom();
+
+  // Cycle 1 → 2 → 3 → 1 … every 400 ms
+  let count = 1;
+  thinkingInterval = setInterval(() => {
+    count = (count % 3) + 1;
+    dots.textContent = ".".repeat(count);
+  }, 400);
 }
 
 function clearThinking() {
+  if (thinkingInterval) { clearInterval(thinkingInterval); thinkingInterval = null; }
   if (pendingTurn) { pendingTurn.remove(); pendingTurn = null; }
 }
 

--- a/voice/requirements.txt
+++ b/voice/requirements.txt
@@ -28,12 +28,14 @@ torchaudio>=2.1.0     # Audio I/O backend used by Whisper
 pyaudio==0.2.14
 
 # ── Text-to-speech ───────────────────────────────────────────────────────────
-# Piper TTS — local, offline neural TTS (used as an external binary subprocess)
-# The piper-tts PyPI package is NOT listed here — its piper-phonemize dependency
-# has no Python 3.12+ wheels.  Instead, tts.py auto-downloads the piper binary
-# from https://github.com/rhasspy/piper/releases and calls it via subprocess.
-# Voice ONNX models are also auto-downloaded from HuggingFace on first run.
-# See voice/README.md for manual installation instructions.
+# edge-tts — Microsoft Azure Neural TTS voices (requires internet)
+# Streams high-quality voices (Jenny, Guy, Aria, Davis…) via the Edge read-aloud API.
+# No API key required. Voice names: https://bit.ly/edge-tts-voices
+edge-tts>=6.1.9
+
+# miniaudio — pure-Python MP3/WAV/OGG decoder (no ffmpeg required)
+# Used to decode the MP3 audio stream from edge-tts into WAV for PyAudio playback.
+miniaudio>=1.59
 
 # ── HTTP client (talk to Charles API) ───────────────────────────────────────
 requests==2.31.0

--- a/voice/tts.py
+++ b/voice/tts.py
@@ -39,9 +39,10 @@ logger = logging.getLogger(__name__)
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 
-EDGE_VOICE: str  = os.getenv("EDGE_VOICE",  "en-US-GuyNeural")
+EDGE_VOICE: str  = os.getenv("EDGE_VOICE",  "en-GB-RyanNeural")
 EDGE_RATE: str   = os.getenv("EDGE_RATE",   "+0%")
 EDGE_VOLUME: str = os.getenv("EDGE_VOLUME", "+0%")
+EDGE_PITCH: str  = os.getenv("EDGE_PITCH",  "-10Hz")  # negative = deeper; sweet spot: -5Hz to -15Hz
 
 # ── Text preprocessing ────────────────────────────────────────────────────────
 
@@ -104,7 +105,7 @@ def stop_speaking() -> None:
 
 async def _generate_mp3(text: str) -> bytes:
     """Stream audio from edge-tts and return the full MP3 bytes."""
-    communicate = edge_tts.Communicate(text, voice=EDGE_VOICE, rate=EDGE_RATE, volume=EDGE_VOLUME)
+    communicate = edge_tts.Communicate(text, voice=EDGE_VOICE, rate=EDGE_RATE, volume=EDGE_VOLUME, pitch=EDGE_PITCH)
     buf = io.BytesIO()
     async for chunk in communicate.stream():
         if chunk["type"] == "audio":
@@ -180,4 +181,4 @@ def preload() -> None:
     This function exists so main.py can call it unconditionally without
     needing to know which TTS engine is in use.
     """
-    logger.info("Edge TTS ready (voice=%s, rate=%s)", EDGE_VOICE, EDGE_RATE)
+    logger.info("Edge TTS ready (voice=%s, rate=%s, pitch=%s)", EDGE_VOICE, EDGE_RATE, EDGE_PITCH)

--- a/voice/tts.py
+++ b/voice/tts.py
@@ -1,39 +1,37 @@
 """
-tts.py — Piper text-to-speech pipeline.
+tts.py — Microsoft Edge Neural TTS pipeline.
 
-Piper is a local, offline neural TTS engine.  It ships as a standalone binary
-that reads text from stdin and writes a WAV file to stdout.
+Uses edge-tts to stream high-quality Azure Neural voices (no API key needed).
+Audio is returned as MP3, decoded in-process by miniaudio, then played via
+the same play_wav_bytes() path as before.
 
-Binary location (relative to this file):
-    Windows : voice/bin/piper.exe
-    macOS   : voice/bin/piper
-    Linux   : voice/bin/piper
+Voice options (default: en-US-GuyNeural)
+-----------------------------------------
+  Male   : en-US-GuyNeural, en-US-DavisNeural, en-US-ChristopherNeural
+  Female : en-US-JennyNeural, en-US-AriaNeural, en-US-SaraNeural
 
-Voice model (ONNX + JSON config):
-    voice/models/en_US-lessac-medium.onnx          (or whichever you chose)
-    voice/models/en_US-lessac-medium.onnx.json
-
-Both the binary and models auto-download on first run via `_ensure_assets()`.
-
-Voices are sourced from https://huggingface.co/rhasspy/piper-voices
+Override with EDGE_VOICE in your .env file.
+Full voice list: https://bit.ly/edge-tts-voices
 
 Environment variables:
-    PIPER_VOICE   — model name without extension (default: en_US-lessac-medium)
-    PIPER_RATE    — playback speed [0.5 – 2.0]   (default: 1.0)
+    EDGE_VOICE   — voice name          (default: en-US-GuyNeural)
+    EDGE_RATE    — speed adjustment    (default: +0%, try +10% for slightly faster)
+    EDGE_VOLUME  — volume adjustment   (default: +0%)
 """
 
 from __future__ import annotations
 
+import asyncio
 import io
 import logging
 import os
-import platform
-import subprocess
-import sys
+import re
 import threading
-import urllib.request
-from pathlib import Path
+import wave
 from typing import Optional
+
+import edge_tts
+import miniaudio
 
 from audio import play_wav_bytes
 
@@ -41,112 +39,49 @@ logger = logging.getLogger(__name__)
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 
-_VOICE_DIR = Path(__file__).parent
-_BIN_DIR = _VOICE_DIR / "bin"
-_MODELS_DIR = _VOICE_DIR / "models"
+EDGE_VOICE: str  = os.getenv("EDGE_VOICE",  "en-US-GuyNeural")
+EDGE_RATE: str   = os.getenv("EDGE_RATE",   "+0%")
+EDGE_VOLUME: str = os.getenv("EDGE_VOLUME", "+0%")
 
-PIPER_VOICE: str = os.getenv("PIPER_VOICE", "en_US-lessac-medium")
-PIPER_RATE: float = float(os.getenv("PIPER_RATE", "1.0"))
+# ── Text preprocessing ────────────────────────────────────────────────────────
 
-# Piper binary name per platform
-_PIPER_BINARY: str = "piper.exe" if platform.system() == "Windows" else "piper"
-# The piper release zip extracts into a 'piper/' subdirectory inside _BIN_DIR
-# e.g.  voice/bin/piper/piper.exe  (not  voice/bin/piper.exe)
-PIPER_BIN: Path = _BIN_DIR / "piper" / _PIPER_BINARY
-
-# Hugging Face base URL for model downloads
-_HF_BASE = "https://huggingface.co/rhasspy/piper-voices/resolve/main"
-
-# ── Auto-download assets ──────────────────────────────────────────────────────
-
-def _hf_voice_url(voice: str, filename: str) -> str:
+def _clean_for_tts(text: str) -> str:
     """
-    Build a Hugging Face URL for a piper-voices model file.
+    Strip Markdown formatting and normalise punctuation before synthesis.
 
-    Piper voice names follow the pattern:  {lang}_{country}-{name}-{quality}
-    e.g.  en_US-lessac-medium → en/en_US/lessac/medium/
+    LLM responses are written in Markdown for the web UI — feeding them raw
+    to TTS causes Charles to say things like "asterisk asterisk" or "hash hash".
+    This function strips those artefacts so only natural spoken text remains.
     """
-    parts = voice.split("-")          # ["en_US", "lessac", "medium"]
-    lang_country = parts[0]           # "en_US"
-    lang = lang_country.split("_")[0] # "en"
-    name = parts[1] if len(parts) > 1 else "default"
-    quality = parts[2] if len(parts) > 2 else "medium"
-    path = f"{lang}/{lang_country}/{name}/{quality}/{filename}"
-    return f"{_HF_BASE}/{path}"
+    # ── Code blocks: replace with a brief spoken label so the user knows
+    #    something was omitted rather than hearing garbled symbols
+    text = re.sub(r'```[\s\S]*?```', 'code block omitted', text)
+    text = re.sub(r'`([^`]+)`', r'\1', text)           # inline code → bare text
 
+    # ── Markdown formatting characters
+    text = re.sub(r'\*\*(.+?)\*\*', r'\1', text)       # **bold**
+    text = re.sub(r'\*(.+?)\*',     r'\1', text)        # *italic*
+    text = re.sub(r'__(.+?)__',     r'\1', text)        # __bold__
+    text = re.sub(r'_(.+?)_',       r'\1', text)        # _italic_
+    text = re.sub(r'~~(.+?)~~',     r'\1', text)        # ~~strikethrough~~
+    text = re.sub(r'#{1,6}\s+',     '',    text)        # ## Headings
+    text = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', text)  # [link](url) → link text
 
-def _download(url: str, dest: Path) -> None:
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    logger.info("Downloading %s → %s", url, dest)
-    with urllib.request.urlopen(url) as resp, open(dest, "wb") as f:
-        f.write(resp.read())
-    logger.info("Downloaded %s", dest.name)
+    # ── List items: strip bullet/number characters
+    text = re.sub(r'^\s*[-*+]\s+', '',  text, flags=re.MULTILINE)
+    text = re.sub(r'^\s*\d+\.\s+', '',  text, flags=re.MULTILINE)
 
+    # ── Horizontal rules and repeated punctuation
+    text = re.sub(r'-{2,}',  ' ',  text)               # --- → space
+    text = re.sub(r'={2,}',  ' ',  text)               # === → space
+    text = re.sub(r'\.{2,}', '.',  text)               # ... → single period
+    text = re.sub(r'[*_~|>]+', '', text)               # stray Markdown characters
 
-def _ensure_assets() -> None:
-    """
-    Download the Piper binary and voice model if they are not already present.
+    # ── Whitespace normalisation
+    text = re.sub(r'\n+', ' ', text)                   # newlines → spaces
+    text = re.sub(r' {2,}', ' ', text)                 # collapse multiple spaces
 
-    Users can also download manually and skip this step — see voice/README.md.
-    """
-    _BIN_DIR.mkdir(parents=True, exist_ok=True)
-    _MODELS_DIR.mkdir(parents=True, exist_ok=True)
-
-    # ── Binary ───────────────────────────────────────────────────────────────
-    if not PIPER_BIN.exists():
-        system = platform.system()
-        machine = platform.machine().lower()
-
-        # Map to Piper release asset names
-        asset_map = {
-            ("Windows", "amd64"): "piper_windows_amd64.zip",
-            ("Windows", "x86_64"): "piper_windows_amd64.zip",
-            ("Darwin", "arm64"): "piper_macos_aarch64.tar.gz",
-            ("Darwin", "x86_64"): "piper_macos_x86_64.tar.gz",
-            ("Linux", "aarch64"): "piper_linux_aarch64.tar.gz",
-            ("Linux", "arm64"): "piper_linux_aarch64.tar.gz",
-            ("Linux", "x86_64"): "piper_linux_x86_64.tar.gz",
-            ("Linux", "amd64"): "piper_linux_x86_64.tar.gz",
-        }
-        asset = asset_map.get((system, machine))
-        if asset is None:
-            raise RuntimeError(
-                f"No pre-built Piper binary for {system}/{machine}. "
-                "Download manually from https://github.com/rhasspy/piper/releases "
-                f"and place the binary at {PIPER_BIN}"
-            )
-
-        release_url = f"https://github.com/rhasspy/piper/releases/latest/download/{asset}"
-        archive_path = _BIN_DIR / asset
-        _download(release_url, archive_path)
-
-        # Extract
-        if asset.endswith(".zip"):
-            import zipfile
-            with zipfile.ZipFile(archive_path) as z:
-                z.extractall(_BIN_DIR)
-        else:
-            import tarfile
-            with tarfile.open(archive_path) as t:
-                t.extractall(_BIN_DIR)
-
-        archive_path.unlink(missing_ok=True)
-
-        # Make executable on Unix
-        if system != "Windows":
-            PIPER_BIN.chmod(0o755)
-
-        logger.info("Piper binary ready at %s", PIPER_BIN)
-
-    # ── Voice model ──────────────────────────────────────────────────────────
-    onnx_path = _MODELS_DIR / f"{PIPER_VOICE}.onnx"
-    json_path = _MODELS_DIR / f"{PIPER_VOICE}.onnx.json"
-
-    if not onnx_path.exists():
-        _download(_hf_voice_url(PIPER_VOICE, f"{PIPER_VOICE}.onnx"), onnx_path)
-
-    if not json_path.exists():
-        _download(_hf_voice_url(PIPER_VOICE, f"{PIPER_VOICE}.onnx.json"), json_path)
+    return text.strip()
 
 
 # ── Interruption support ──────────────────────────────────────────────────────
@@ -165,6 +100,35 @@ def stop_speaking() -> None:
     _stop_playback.set()
 
 
+# ── Audio generation ──────────────────────────────────────────────────────────
+
+async def _generate_mp3(text: str) -> bytes:
+    """Stream audio from edge-tts and return the full MP3 bytes."""
+    communicate = edge_tts.Communicate(text, voice=EDGE_VOICE, rate=EDGE_RATE, volume=EDGE_VOLUME)
+    buf = io.BytesIO()
+    async for chunk in communicate.stream():
+        if chunk["type"] == "audio":
+            buf.write(chunk["data"])
+    return buf.getvalue()
+
+
+def _mp3_to_wav(mp3_bytes: bytes) -> bytes:
+    """Decode MP3 bytes to WAV bytes using miniaudio (no ffmpeg required)."""
+    decoded = miniaudio.decode(
+        mp3_bytes,
+        output_format=miniaudio.SampleFormat.SIGNED16,
+        nchannels=1,
+        sample_rate=24_000,
+    )
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)          # 16-bit
+        wf.setframerate(24_000)
+        wf.writeframes(bytes(decoded.samples))
+    return buf.getvalue()
+
+
 # ── Public API ────────────────────────────────────────────────────────────────
 
 def speak(
@@ -179,8 +143,8 @@ def speak(
     Parameters
     ----------
     text
-        The text to synthesise.  Markdown and special characters are passed
-        through — Piper handles most punctuation gracefully.
+        The text to synthesise.  Markdown is stripped automatically by
+        ``_clean_for_tts`` before the text is sent to the TTS engine.
     output_device_index
         Speaker device index.  None → system default.
     """
@@ -188,81 +152,32 @@ def speak(
         return
 
     _stop_playback.clear()
+    clean = _clean_for_tts(text)
 
-    try:
-        _ensure_assets()
-    except Exception as exc:
-        logger.error("Could not ensure Piper assets: %s", exc)
+    if not clean:
         return
 
-    onnx_path = _MODELS_DIR / f"{PIPER_VOICE}.onnx"
-
-    cmd: list[str] = [
-        str(PIPER_BIN),
-        "--model", str(onnx_path),
-        "--output-raw",             # raw PCM stdout (we wrap it in WAV ourselves)
-        "--sentence-silence", "0.2",
-    ]
-
-    if PIPER_RATE != 1.0:
-        cmd += ["--length-scale", str(1.0 / PIPER_RATE)]  # Piper uses length-scale (inverse of rate)
-
-    logger.info("Speaking: %r", text[:80])
+    logger.info("Speaking: %r", clean[:80])
 
     with _playback_lock:
         try:
-            proc = subprocess.Popen(
-                cmd,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-
-            # Feed text to piper, read raw PCM output
-            stdout, stderr = proc.communicate(input=text.encode("utf-8"), timeout=30)
-
-            if proc.returncode != 0:
-                logger.error("Piper error: %s", stderr.decode(errors="replace"))
-                return
+            mp3_bytes = asyncio.run(_generate_mp3(clean))
 
             if _stop_playback.is_set():
                 logger.debug("TTS playback aborted before it started")
                 return
 
-            # Piper --output-raw produces headerless 16-bit mono PCM at the
-            # model's native sample rate (usually 22 050 Hz).  Wrap it in a
-            # WAV header so play_wav_bytes() can handle it.
-            wav_bytes = _pcm_to_wav(stdout, sample_rate=22_050, channels=1, sample_width=2)
+            wav_bytes = _mp3_to_wav(mp3_bytes)
             play_wav_bytes(wav_bytes, output_device_index=output_device_index)
 
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            logger.error("Piper timed out")
         except Exception as exc:
             logger.error("TTS error: %s", exc, exc_info=True)
 
 
-def _pcm_to_wav(pcm: bytes, sample_rate: int, channels: int, sample_width: int) -> bytes:
-    """Wrap raw PCM bytes in a RIFF/WAV header."""
-    import wave
-    buf = io.BytesIO()
-    with wave.open(buf, "wb") as wf:
-        wf.setnchannels(channels)
-        wf.setsampwidth(sample_width)
-        wf.setframerate(sample_rate)
-        wf.writeframes(pcm)
-    return buf.getvalue()
-
-
 def preload() -> None:
     """
-    Ensure the Piper binary and voice model are downloaded at startup.
-
-    Call this before the first ``speak()`` so the first voice interaction
-    doesn't stall on a download.
+    edge-tts streams from the cloud on each call — nothing to preload.
+    This function exists so main.py can call it unconditionally without
+    needing to know which TTS engine is in use.
     """
-    try:
-        _ensure_assets()
-        logger.info("Piper TTS assets ready (voice=%s)", PIPER_VOICE)
-    except Exception as exc:
-        logger.error("Failed to preload Piper assets: %s", exc)
+    logger.info("Edge TTS ready (voice=%s, rate=%s)", EDGE_VOICE, EDGE_RATE)


### PR DESCRIPTION
## Summary

- **TTS overhaul** — Piper (offline, robotic) replaced with edge-tts using Microsoft Azure Neural voices. Default voice is `en-GB-RyanNeural` at `-10Hz` pitch for a deeper, more natural tone. Markdown is stripped before synthesis so Charles never speaks asterisks or hash symbols.
- **Thinking indicator** — replaced the blinking ellipsis with a sequential 1 → 2 → 3 → 1 dot animation driven by `setInterval`, cancellable on demand.
- **Gitignore** — `.superpowers/`, `.claude/`, and `voice/preview_*.wav` excluded.

## New env vars
| Var | Default | Purpose |
|---|---|---|
| `EDGE_VOICE` | `en-GB-RyanNeural` | Azure Neural voice name |
| `EDGE_RATE` | `+0%` | Speaking speed |
| `EDGE_PITCH` | `-10Hz` | Pitch shift (negative = deeper) |
| `EDGE_VOLUME` | `+0%` | Volume |

## New deps (run `pip install -r voice/requirements.txt`)
- `edge-tts>=6.1.9`
- `miniaudio>=1.59`