### PR TITLE
feat: installation wizard + model selector

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -53,15 +53,15 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
+    # Only browser-based clients need CORS — Python services bypass it entirely.
+    # The Electron renderer uses file:// origin in prod and localhost:8000 in dev.
     allow_origins=[
-        "http://localhost:8000",   # Electron renderer / browser fallback
-        "http://localhost:8001",   # Voice service
+        "http://localhost:8000",
         "http://127.0.0.1:8000",
-        "http://127.0.0.1:8001",
     ],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization"],
 )
 
 app.include_router(chat.router)

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -8,7 +8,7 @@ from fastapi.staticfiles import StaticFiles
 from sqlalchemy import text
 
 from app.database import engine, ping_db
-from app.routers import chat, history, openai_compat
+from app.routers import chat, history, openai_compat, settings
 from app.services.ws_manager import manager
 
 _STATIC_DIR = os.path.join(os.path.dirname(__file__), "static")
@@ -67,6 +67,7 @@ app.add_middleware(
 app.include_router(chat.router)
 app.include_router(history.router)
 app.include_router(openai_compat.router)
+app.include_router(settings.router)
 
 app.mount("/static", StaticFiles(directory=_STATIC_DIR), name="static")
 

--- a/api/app/routers/chat.py
+++ b/api/app/routers/chat.py
@@ -51,9 +51,15 @@ async def chat(request: ChatRequest, db: AsyncSession = Depends(get_db)):
     )
     await db.commit()
 
-    # 4. Call OpenRouter
+    # 4. Resolve the active model (set via PUT /settings/model; falls back to env default)
+    model_row = (await db.execute(
+        text("SELECT value FROM app_state WHERE key = 'active_model'")
+    )).fetchone()
+    active_model = model_row[0] if model_row else None
+
+    # 5. Call OpenRouter
     try:
-        assistant_reply = await get_openrouter_response(history)
+        assistant_reply = await get_openrouter_response(history, model=active_model)
     except httpx.HTTPStatusError as e:
         status = e.response.status_code
         if status == 429:
@@ -69,7 +75,7 @@ async def chat(request: ChatRequest, db: AsyncSession = Depends(get_db)):
     except httpx.TimeoutException:
         raise HTTPException(status_code=504, detail="OpenRouter timed out. Try again.")
 
-    # 5. Store assistant reply
+    # 6. Store assistant reply
     assistant_message_id = str(uuid.uuid4())
     await db.execute(
         text("""
@@ -80,7 +86,7 @@ async def chat(request: ChatRequest, db: AsyncSession = Depends(get_db)):
     )
     await db.commit()
 
-    # 6. Broadcast to all connected WebSocket clients
+    # 7. Broadcast to all connected WebSocket clients
     await manager.broadcast({
         "type": "turn",
         "interface": request.interface,

--- a/api/app/routers/settings.py
+++ b/api/app/routers/settings.py
@@ -1,0 +1,105 @@
+"""
+settings.py — User-facing configuration endpoints.
+
+GET  /settings/model  — return the currently active OpenRouter model ID
+PUT  /settings/model  — persist a new model selection to app_state
+GET  /models          — proxy OpenRouter's model catalogue (5-min TTL cache)
+"""
+
+import os
+import time
+from dotenv import load_dotenv
+
+import httpx
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+
+load_dotenv()
+
+_DEFAULT_MODEL    = os.getenv("OPENROUTER_MODEL", "deepseek/deepseek-v3.2")
+_OPENROUTER_KEY   = os.getenv("OPENROUTER_API_KEY")
+_MODELS_CACHE_TTL = 300  # seconds
+
+router = APIRouter()
+
+# ── In-process model list cache ───────────────────────────────────────────────
+_cached_models: list[dict]  = []
+_cached_at:     float       = 0.0
+
+
+class ModelSelection(BaseModel):
+    model: str
+
+
+# ── Active model ──────────────────────────────────────────────────────────────
+
+@router.get("/settings/model")
+async def get_active_model(db: AsyncSession = Depends(get_db)):
+    """Return the currently selected model ID."""
+    result = await db.execute(
+        text("SELECT value FROM app_state WHERE key = 'active_model'")
+    )
+    row = result.fetchone()
+    return {"model": row[0] if row else _DEFAULT_MODEL}
+
+
+@router.put("/settings/model")
+async def set_active_model(body: ModelSelection, db: AsyncSession = Depends(get_db)):
+    """Persist the selected model to app_state (upsert)."""
+    await db.execute(
+        text("""
+            INSERT INTO app_state (key, value) VALUES ('active_model', :model)
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        """),
+        {"model": body.model},
+    )
+    await db.commit()
+    return {"model": body.model}
+
+
+# ── Model catalogue ───────────────────────────────────────────────────────────
+
+@router.get("/models")
+async def list_models():
+    """
+    Return the models available on this OpenRouter account.
+
+    Results are cached for 5 minutes to avoid hammering the OpenRouter API.
+    Falls back to the stale cache (or an empty list) if the request fails.
+    """
+    global _cached_models, _cached_at
+
+    now = time.monotonic()
+    if _cached_models and (now - _cached_at) < _MODELS_CACHE_TTL:
+        return {"models": _cached_models}
+
+    if not _OPENROUTER_KEY:
+        return {"models": _cached_models}  # empty on first call, stale on retry
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                "https://openrouter.ai/api/v1/models",
+                headers={"Authorization": f"Bearer {_OPENROUTER_KEY}"},
+            )
+            resp.raise_for_status()
+
+        data = resp.json().get("data", [])
+        models = sorted(
+            [
+                {"id": m["id"], "name": m.get("name", m["id"])}
+                for m in data
+                if m.get("context_length", 0) > 0
+            ],
+            key=lambda m: m["id"],
+        )
+        _cached_models = models
+        _cached_at = now
+    except Exception:
+        pass  # keep serving stale cache
+
+    return {"models": _cached_models}

--- a/api/app/services/openrouter.py
+++ b/api/app/services/openrouter.py
@@ -14,16 +14,18 @@ SYSTEM_PROMPT = (
     "When asked about vulnerabilities or security topics, be thorough but clear."
 )
 
-"""
-Takes full conversation history so that the LLM has context for the whole conversation.
-"""
-async def get_openrouter_response(conversation_history: list[dict]) -> str:
+async def get_openrouter_response(
+    conversation_history: list[dict],
+    model: str | None = None,
+) -> str:
     """
     Send conversation history to OpenRouter and return the assistant reply.
 
     Args:
         conversation_history: List of {"role": ..., "content": ...} dicts
                                representing the full conversation so far.
+        model: OpenRouter model ID to use (e.g. "openai/gpt-4o").
+               Falls back to the OPENROUTER_MODEL env var if not provided.
     Returns:
         The assistant's reply as a plain string.
     Raises:
@@ -44,7 +46,7 @@ async def get_openrouter_response(conversation_history: list[dict]) -> str:
     }
 
     payload = {
-        "model": MODEL,
+        "model": model or MODEL,
         "messages": messages,
     }
 

--- a/api/main.py
+++ b/api/main.py
@@ -9,4 +9,4 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import uvicorn
 
 if __name__ == "__main__":
-    uvicorn.run("app.main:app", host="0.0.0.0", port=8000)
+    uvicorn.run("app.main:app", host="127.0.0.1", port=8000)

--- a/launcher/main.js
+++ b/launcher/main.js
@@ -43,6 +43,7 @@ function createWindow() {
     },
   })
   mainWindow.loadFile(path.join(__dirname, 'renderer', 'index.html'))
+  mainWindow.webContents.openDevTools({ mode: 'detach' })
   mainWindow.on('close', (e) => {
     if (!app.isQuiting) { e.preventDefault(); mainWindow.hide() }
   })
@@ -129,6 +130,7 @@ async function startApi() {
 
   try {
     await pollHealth()
+    console.log('[main] pollHealth resolved, sending ready. mainWindow:', !!mainWindow)
     mainWindow?.webContents.send('status-update', { state: 'ready' })
   } catch (err) {
     apiProcess?.kill(); apiProcess = null

--- a/launcher/main.js
+++ b/launcher/main.js
@@ -43,7 +43,6 @@ function createWindow() {
     },
   })
   mainWindow.loadFile(path.join(__dirname, 'renderer', 'index.html'))
-  mainWindow.webContents.openDevTools({ mode: 'detach' })
   mainWindow.on('close', (e) => {
     if (!app.isQuiting) { e.preventDefault(); mainWindow.hide() }
   })
@@ -130,7 +129,6 @@ async function startApi() {
 
   try {
     await pollHealth()
-    console.log('[main] pollHealth resolved, sending ready. mainWindow:', !!mainWindow)
     mainWindow?.webContents.send('status-update', { state: 'ready' })
   } catch (err) {
     apiProcess?.kill(); apiProcess = null
@@ -212,6 +210,13 @@ function launchMain() {
   // events aren't dropped before the listener is registered.
   mainWindow.webContents.once('did-finish-load', () => startApi())
 }
+
+// Prevent multiple instances — if a second instance is launched, focus
+// the existing window instead of starting a new one.
+if (!app.requestSingleInstanceLock()) {
+  app.quit()
+}
+app.on('second-instance', () => { mainWindow?.show(); mainWindow?.focus() })
 
 app.whenReady().then(() => {
   if (fs.existsSync(setupFlagPath)) {

--- a/launcher/main.js
+++ b/launcher/main.js
@@ -203,7 +203,9 @@ function launchMain() {
   createWindow()
   createTray()
   registerIPC()
-  startApi()
+  // Defer startApi until the renderer has finished loading so IPC status
+  // events aren't dropped before the listener is registered.
+  mainWindow.webContents.once('did-finish-load', () => startApi())
 }
 
 app.whenReady().then(() => {

--- a/launcher/main.js
+++ b/launcher/main.js
@@ -11,8 +11,10 @@
 
 const { app, BrowserWindow, ipcMain, nativeImage, Tray, Menu } = require('electron')
 const path   = require('path')
+const fs     = require('fs')
 const http   = require('http')
 const { spawn } = require('child_process')
+const { createWizardWindow, setupFlagPath } = require('./wizard')
 
 const isPacked    = app.isPackaged
 const apiScript   = isPacked
@@ -183,11 +185,20 @@ function registerIPC() {
 }
 
 // ── App lifecycle ─────────────────────────────────────────────────────────────
-app.whenReady().then(() => {
+
+function launchMain() {
   createWindow()
   createTray()
   registerIPC()
-  startApi()   // API starts automatically — no user action needed
+  startApi()
+}
+
+app.whenReady().then(() => {
+  if (fs.existsSync(setupFlagPath)) {
+    launchMain()
+  } else {
+    createWizardWindow({ onComplete: launchMain })
+  }
 })
 app.on('before-quit', () => stopAll())
 app.on('window-all-closed', (e) => e.preventDefault())

--- a/launcher/main.js
+++ b/launcher/main.js
@@ -90,7 +90,7 @@ function pollHealth(maxAttempts = 15) {
     const check = () => {
       attempts++
       if (attempts > maxAttempts) { reject(new Error(`API did not start after ${maxAttempts * 2}s`)); return }
-      const req = http.get('http://localhost:8000/health', (res) => {
+      const req = http.get('http://127.0.0.1:8000/health', (res) => {
         res.resume()
         if (res.statusCode === 200) resolve(); else setTimeout(check, 2000)
       })
@@ -103,6 +103,9 @@ function pollHealth(maxAttempts = 15) {
 
 // ── API lifecycle (automatic) ─────────────────────────────────────────────────
 async function startApi() {
+  // Kill any leftover API process (e.g. from a previous instance that hid to tray)
+  if (apiProcess) { try { apiProcess.kill() } catch {} ; apiProcess = null }
+
   mainWindow?.webContents.send('status-update', { state: 'initializing' })
 
   const proc = spawn('python', [apiScript], {

--- a/launcher/main.js
+++ b/launcher/main.js
@@ -65,6 +65,19 @@ function createTray() {
   tray.setContextMenu(Menu.buildFromTemplate([
     { label: 'Show', click: () => mainWindow?.show() },
     { type: 'separator' },
+    {
+      label: 'Re-run Setup…',
+      click: () => {
+        // Delete the setup flag so the wizard opens on next launch,
+        // then restart the app so the change takes effect.
+        try { fs.unlinkSync(setupFlagPath) } catch {}
+        app.isQuiting = true
+        stopAll()
+        app.relaunch()
+        app.quit()
+      },
+    },
+    { type: 'separator' },
     { label: 'Quit', click: () => { app.isQuiting = true; stopAll(); app.quit() } },
   ]))
   tray.on('double-click', () => mainWindow?.show())

--- a/launcher/preload-wizard.js
+++ b/launcher/preload-wizard.js
@@ -14,4 +14,6 @@ contextBridge.exposeInMainWorld('wizardAPI', {
     ipcRenderer.on('wizard:install-progress', listener)
     return () => ipcRenderer.removeListener('wizard:install-progress', listener)
   },
+
+  openExternal: (url) => ipcRenderer.invoke('wizard:open-external', url),
 })

--- a/launcher/preload-wizard.js
+++ b/launcher/preload-wizard.js
@@ -1,0 +1,16 @@
+const { contextBridge, ipcRenderer } = require('electron')
+
+contextBridge.exposeInMainWorld('wizardAPI', {
+  checkPython:   ()     => ipcRenderer.invoke('wizard:check-python'),
+  installDeps:   ()     => ipcRenderer.invoke('wizard:install-deps'),
+  validateKeys:  (keys) => ipcRenderer.invoke('wizard:validate-keys', keys),
+  saveKeys:      (keys) => ipcRenderer.invoke('wizard:save-keys', keys),
+  finish:        ()     => ipcRenderer.invoke('wizard:finish'),
+  close:         ()     => ipcRenderer.invoke('wizard:close'),
+
+  onInstallProgress: (cb) => {
+    const listener = (_, d) => cb(d)
+    ipcRenderer.on('wizard:install-progress', listener)
+    return () => ipcRenderer.removeListener('wizard:install-progress', listener)
+  },
+})

--- a/launcher/preload-wizard.js
+++ b/launcher/preload-wizard.js
@@ -1,10 +1,9 @@
 const { contextBridge, ipcRenderer } = require('electron')
 
 contextBridge.exposeInMainWorld('wizardAPI', {
-  checkPython:          ()     => ipcRenderer.invoke('wizard:check-python'),
-  installDeps:          ()     => ipcRenderer.invoke('wizard:install-deps'),
-  startOpenRouterOAuth: ()     => ipcRenderer.invoke('wizard:start-openrouter-oauth'),
-  validatePicovoice:    (key)  => ipcRenderer.invoke('wizard:validate-picovoice', { picovoiceKey: key }),
+  checkPython:       ()     => ipcRenderer.invoke('wizard:check-python'),
+  installDeps:       ()     => ipcRenderer.invoke('wizard:install-deps'),
+  validatePicovoice: (key)  => ipcRenderer.invoke('wizard:validate-picovoice', { picovoiceKey: key }),
   saveKeys:             (keys) => ipcRenderer.invoke('wizard:save-keys', keys),
   finish:               ()     => ipcRenderer.invoke('wizard:finish'),
   close:                ()     => ipcRenderer.invoke('wizard:close'),

--- a/launcher/preload-wizard.js
+++ b/launcher/preload-wizard.js
@@ -1,12 +1,13 @@
 const { contextBridge, ipcRenderer } = require('electron')
 
 contextBridge.exposeInMainWorld('wizardAPI', {
-  checkPython:   ()     => ipcRenderer.invoke('wizard:check-python'),
-  installDeps:   ()     => ipcRenderer.invoke('wizard:install-deps'),
-  validateKeys:  (keys) => ipcRenderer.invoke('wizard:validate-keys', keys),
-  saveKeys:      (keys) => ipcRenderer.invoke('wizard:save-keys', keys),
-  finish:        ()     => ipcRenderer.invoke('wizard:finish'),
-  close:         ()     => ipcRenderer.invoke('wizard:close'),
+  checkPython:          ()     => ipcRenderer.invoke('wizard:check-python'),
+  installDeps:          ()     => ipcRenderer.invoke('wizard:install-deps'),
+  startOpenRouterOAuth: ()     => ipcRenderer.invoke('wizard:start-openrouter-oauth'),
+  validatePicovoice:    (key)  => ipcRenderer.invoke('wizard:validate-picovoice', { picovoiceKey: key }),
+  saveKeys:             (keys) => ipcRenderer.invoke('wizard:save-keys', keys),
+  finish:               ()     => ipcRenderer.invoke('wizard:finish'),
+  close:                ()     => ipcRenderer.invoke('wizard:close'),
 
   onInstallProgress: (cb) => {
     const listener = (_, d) => cb(d)

--- a/launcher/renderer/index.html
+++ b/launcher/renderer/index.html
@@ -260,8 +260,8 @@
 
 <script>
 // ── Config ────────────────────────────────────────────────────────────────────
-const API_BASE = 'http://localhost:8000';
-const WS_URL   = 'ws://localhost:8000/ws';
+const API_BASE = 'http://127.0.0.1:8000';
+const WS_URL   = 'ws://127.0.0.1:8000/ws';
 
 // ── State ─────────────────────────────────────────────────────────────────────
 let conversationId      = null;   // set after first turn or history load

--- a/launcher/renderer/index.html
+++ b/launcher/renderer/index.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';
+                 connect-src http://127.0.0.1:8000 ws://127.0.0.1:8000;" />
   <title>Charles</title>
   <script src="lib/marked.min.js"></script>
   <script src="lib/purify.min.js"></script>

--- a/launcher/renderer/index.html
+++ b/launcher/renderer/index.html
@@ -205,6 +205,20 @@
     #stop-btn:hover { background:#991b1b; }
     #msg-input:disabled { opacity:.4; cursor:not-allowed; }
 
+    #model-select {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text-muted);
+      font-size: .72rem;
+      padding: 3px 6px 3px 8px;
+      cursor: pointer;
+      max-width: 160px;
+      -webkit-app-region: no-drag;
+    }
+    #model-select:focus { outline: none; border-color: var(--accent); }
+    #model-select option { background: #1a1a1a; }
+
     .win-controls { margin-left:auto; display:flex; gap:4px; -webkit-app-region:no-drag; }
     .win-controls button {
       width:28px; height:22px; border:none; border-radius:4px;
@@ -228,6 +242,9 @@
   <span id="voice-pill"></span>
   <button id="start-btn">Start</button>
   <button id="stop-btn" style="display:none">Stop</button>
+  <select id="model-select" title="Active model">
+    <option disabled selected>Loading models…</option>
+  </select>
   <div class="win-controls">
     <button id="btn-minimize" title="Minimize">&#8722;</button>
     <button id="btn-close"    title="Close">&#x2715;</button>
@@ -524,6 +541,49 @@ function setVoiceState(state) {
 $startBtn.addEventListener('click', () => window.electronAPI.start());
 $stopBtn.addEventListener('click',  () => window.electronAPI.stop());
 
+// ── Model selector ────────────────────────────────────────────────────────────
+const $modelSelect = document.getElementById('model-select');
+let modelSelectReady = false;
+
+async function initModelSelector() {
+  if (modelSelectReady) return;
+  try {
+    const [listRes, currentRes] = await Promise.all([
+      fetch(`${API_BASE}/models`),
+      fetch(`${API_BASE}/settings/model`),
+    ]);
+    const { models }       = await listRes.json();
+    const { model: active } = await currentRes.json();
+
+    $modelSelect.textContent = '';
+    for (const m of models) {
+      const opt = document.createElement('option');
+      opt.value       = m.id;
+      opt.textContent = m.name;
+      if (m.id === active) opt.selected = true;
+      $modelSelect.appendChild(opt);
+    }
+    // If the active model isn't in the returned list, prepend it so the
+    // UI always reflects the real selection (e.g. set via env var).
+    if ($modelSelect.value !== active) {
+      const opt = document.createElement('option');
+      opt.value = active; opt.textContent = active; opt.selected = true;
+      $modelSelect.insertBefore(opt, $modelSelect.firstChild);
+    }
+    modelSelectReady = true;
+  } catch {
+    $modelSelect.options[0].textContent = 'Model unavailable';
+  }
+}
+
+$modelSelect.addEventListener('change', () => {
+  fetch(`${API_BASE}/settings/model`, {
+    method:  'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body:    JSON.stringify({ model: $modelSelect.value }),
+  });
+});
+
 // Window chrome controls (frameless window has no native buttons)
 document.getElementById('btn-minimize').addEventListener('click', () => window.electronAPI.minimize());
 document.getElementById('btn-close').addEventListener('click',    () => window.electronAPI.closeWindow());
@@ -535,6 +595,7 @@ const cleanupStatus = window.electronAPI.onStatusUpdate(({ state, message }) => 
     if (!socket || socket.readyState === WebSocket.CLOSED) {
       loadHistory().then(() => connectWebSocket());
     }
+    initModelSelector();
   }
 });
 const cleanupVoice      = window.electronAPI.onVoiceState(({ state }) => setVoiceState(state));

--- a/launcher/renderer/index.html
+++ b/launcher/renderer/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';
+        content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';
                  connect-src http://127.0.0.1:8000 ws://127.0.0.1:8000;" />
   <title>Charles</title>
   <script src="lib/marked.min.js"></script>

--- a/launcher/renderer/wizard.html
+++ b/launcher/renderer/wizard.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';" />
   <title>Charles — Setup</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/launcher/renderer/wizard.html
+++ b/launcher/renderer/wizard.html
@@ -218,7 +218,7 @@
       <h2>Connect Accounts</h2>
       <p>Charles needs two things: an AI provider and a wake word licence. Both are free.</p>
 
-      <!-- OpenRouter OAuth -->
+      <!-- OpenRouter OAuth + manual key fallback -->
       <div class="field">
         <label>AI Provider — OpenRouter</label>
         <div id="or-connect-row" style="display:flex; align-items:center; gap:10px;">
@@ -227,7 +227,14 @@
           </button>
           <span id="or-status" style="font-size:.82rem; color:var(--text-muted);">Opens your browser</span>
         </div>
-        <span class="hint">Sign in with Google or GitHub — no key to copy/paste</span>
+        <span class="hint">Sign in with Google or GitHub — no key to copy/paste &nbsp;·&nbsp; <a id="link-manual-key" style="color:var(--accent);cursor:pointer;text-decoration:underline;">I already have an API key</a></span>
+      </div>
+
+      <!-- Manual key input (hidden until "I already have an API key" is clicked) -->
+      <div class="field" id="field-manual-key" style="display:none;">
+        <label>OpenRouter API Key</label>
+        <input type="password" id="input-openrouter-key" placeholder="sk-or-v1-…" autocomplete="off" spellcheck="false" />
+        <span class="hint">Find yours at <a id="link-openrouter-keys" style="color:var(--accent);cursor:pointer;text-decoration:underline;">openrouter.ai/keys</a></span>
       </div>
 
       <!-- Picovoice key -->
@@ -364,12 +371,26 @@ document.getElementById('btn-oauth').addEventListener('click', async () => {
     $btn.style.display = 'none'
     $status.style.color = 'var(--success)'
     $status.textContent = '✅ Connected'
+    // Hide manual input if it was open
+    document.getElementById('field-manual-key').style.display = 'none'
   } else {
     oauthKey = null
     $btn.disabled = false
     $status.style.color = 'var(--error)'
     $status.textContent = '❌ ' + result.error
   }
+})
+
+// ── Manual key fallback ────────────────────────────────────────────────────────
+document.getElementById('link-manual-key').addEventListener('click', () => {
+  const $field = document.getElementById('field-manual-key')
+  const visible = $field.style.display !== 'none'
+  $field.style.display = visible ? 'none' : 'block'
+  if (!visible) document.getElementById('input-openrouter-key').focus()
+})
+
+document.getElementById('link-openrouter-keys').addEventListener('click', () => {
+  window.wizardAPI.openExternal('https://openrouter.ai/keys')
 })
 
 // ── Next / Back ────────────────────────────────────────────────────────────────
@@ -382,8 +403,12 @@ $next.addEventListener('click', async () => {
   if (current === 3) {
     const pvKey = document.getElementById('input-picovoice').value.trim()
 
-    if (!oauthKey) {
-      setKeyStatus('⚠️', 'Please connect your OpenRouter account first.', 'fail')
+    // Accept either the OAuth key or the manually entered key
+    const manualKey = document.getElementById('input-openrouter-key').value.trim()
+    const openrouterKey = oauthKey || manualKey
+
+    if (!openrouterKey) {
+      setKeyStatus('⚠️', 'Connect with OpenRouter or enter your API key manually.', 'fail')
       return
     }
     if (!pvKey) {
@@ -401,7 +426,7 @@ $next.addEventListener('click', async () => {
       return
     }
 
-    await window.wizardAPI.saveKeys({ openrouterKey: oauthKey, picovoiceKey: pvKey })
+    await window.wizardAPI.saveKeys({ openrouterKey: openrouterKey, picovoiceKey: pvKey })
     setKeyStatus('✅', 'All set — keys saved', 'ok')
     markStep(3, true)
   }

--- a/launcher/renderer/wizard.html
+++ b/launcher/renderer/wizard.html
@@ -188,6 +188,12 @@
         ② Install Python packages for the API and voice service<br>
         ③ Save your API keys to <code>.env</code>
       </p>
+      <p style="font-size:.8rem; color:var(--text-muted); border-top:1px solid var(--border); padding-top:14px; margin-top:4px; line-height:1.7;">
+        🔒 <strong style="color:var(--text)">Privacy note:</strong>
+        Voice responses are synthesised by Microsoft Azure Neural TTS via the <code>edge-tts</code> library.
+        The text of each response is sent to Microsoft's servers to generate audio.
+        All other processing (wake word, speech-to-text, AI chat) runs locally or through your own API keys.
+      </p>
     </div>
 
     <!-- Step 1: Python -->
@@ -406,9 +412,9 @@ $next.addEventListener('click', async () => {
 $back.addEventListener('click', () => { if (current > 0) goTo(current - 1) })
 document.getElementById('btn-close').addEventListener('click', () => window.wizardAPI.close())
 
-// External links
+// External links — must go via main process shell.openExternal (window.open opens an Electron window)
 document.getElementById('link-picovoice').addEventListener('click', () => {
-  window.open('https://console.picovoice.ai/')
+  window.wizardAPI.openExternal('https://console.picovoice.ai/')
 })
 
 // ── Boot ───────────────────────────────────────────────────────────────────────

--- a/launcher/renderer/wizard.html
+++ b/launcher/renderer/wizard.html
@@ -218,23 +218,11 @@
       <h2>Connect Accounts</h2>
       <p>Charles needs two things: an AI provider and a wake word licence. Both are free.</p>
 
-      <!-- OpenRouter OAuth + manual key fallback -->
+      <!-- OpenRouter API key -->
       <div class="field">
-        <label>AI Provider — OpenRouter</label>
-        <div id="or-connect-row" style="display:flex; align-items:center; gap:10px;">
-          <button id="btn-oauth" style="background:var(--accent);color:#fff;border:none;border-radius:8px;padding:9px 18px;font-size:.88rem;font-weight:600;cursor:pointer;">
-            Connect with OpenRouter
-          </button>
-          <span id="or-status" style="font-size:.82rem; color:var(--text-muted);">Opens your browser</span>
-        </div>
-        <span class="hint">Sign in with Google or GitHub — no key to copy/paste &nbsp;·&nbsp; <a id="link-manual-key" style="color:var(--accent);cursor:pointer;text-decoration:underline;">I already have an API key</a></span>
-      </div>
-
-      <!-- Manual key input (hidden until "I already have an API key" is clicked) -->
-      <div class="field" id="field-manual-key" style="display:none;">
-        <label>OpenRouter API Key</label>
+        <label>AI Provider — OpenRouter API Key</label>
         <input type="password" id="input-openrouter-key" placeholder="sk-or-v1-…" autocomplete="off" spellcheck="false" />
-        <span class="hint">Find yours at <a id="link-openrouter-keys" style="color:var(--accent);cursor:pointer;text-decoration:underline;">openrouter.ai/keys</a></span>
+        <span class="hint">Free at <a id="link-openrouter-keys">openrouter.ai/keys</a> — sign in with Google or GitHub, then create a key</span>
       </div>
 
       <!-- Picovoice key -->
@@ -294,7 +282,6 @@ let current    = 0
 let passed     = [false, false, false, false, false]
 let installing = false
 let cleanupLog = null
-let oauthKey   = null   // OpenRouter key received from OAuth flow
 
 const $next     = document.getElementById('btn-next')
 const $back     = document.getElementById('btn-back')
@@ -357,38 +344,7 @@ async function runInstall() {
   markStep(2, r.ok)
 }
 
-// ── OAuth button ───────────────────────────────────────────────────────────────
-document.getElementById('btn-oauth').addEventListener('click', async () => {
-  const $btn    = document.getElementById('btn-oauth')
-  const $status = document.getElementById('or-status')
-  $btn.disabled = true
-  $status.style.color = ''
-  $status.textContent = '⏳ Waiting for browser…'
-
-  const result = await window.wizardAPI.startOpenRouterOAuth()
-  if (result.ok) {
-    oauthKey = result.key
-    $btn.style.display = 'none'
-    $status.style.color = 'var(--success)'
-    $status.textContent = '✅ Connected'
-    // Hide manual input if it was open
-    document.getElementById('field-manual-key').style.display = 'none'
-  } else {
-    oauthKey = null
-    $btn.disabled = false
-    $status.style.color = 'var(--error)'
-    $status.textContent = '❌ ' + result.error
-  }
-})
-
-// ── Manual key fallback ────────────────────────────────────────────────────────
-document.getElementById('link-manual-key').addEventListener('click', () => {
-  const $field = document.getElementById('field-manual-key')
-  const visible = $field.style.display !== 'none'
-  $field.style.display = visible ? 'none' : 'block'
-  if (!visible) document.getElementById('input-openrouter-key').focus()
-})
-
+// ── External links ─────────────────────────────────────────────────────────────
 document.getElementById('link-openrouter-keys').addEventListener('click', () => {
   window.wizardAPI.openExternal('https://openrouter.ai/keys')
 })
@@ -401,14 +357,11 @@ $next.addEventListener('click', async () => {
   }
 
   if (current === 3) {
-    const pvKey = document.getElementById('input-picovoice').value.trim()
-
-    // Accept either the OAuth key or the manually entered key
-    const manualKey = document.getElementById('input-openrouter-key').value.trim()
-    const openrouterKey = oauthKey || manualKey
+    const openrouterKey = document.getElementById('input-openrouter-key').value.trim()
+    const pvKey         = document.getElementById('input-picovoice').value.trim()
 
     if (!openrouterKey) {
-      setKeyStatus('⚠️', 'Connect with OpenRouter or enter your API key manually.', 'fail')
+      setKeyStatus('⚠️', 'OpenRouter API key is required.', 'fail')
       return
     }
     if (!pvKey) {
@@ -426,7 +379,7 @@ $next.addEventListener('click', async () => {
       return
     }
 
-    await window.wizardAPI.saveKeys({ openrouterKey: openrouterKey, picovoiceKey: pvKey })
+    await window.wizardAPI.saveKeys({ openrouterKey, picovoiceKey: pvKey })
     setKeyStatus('✅', 'All set — keys saved', 'ok')
     markStep(3, true)
   }

--- a/launcher/renderer/wizard.html
+++ b/launcher/renderer/wizard.html
@@ -1,0 +1,380 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Charles — Setup</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:         #0d0d0d;
+      --surface:    #141414;
+      --border:     #2a2a2a;
+      --text:       #e8e8e8;
+      --text-muted: #888;
+      --accent:     #3b82f6;
+      --success:    #22c55e;
+      --error:      #ef4444;
+    }
+
+    html, body { height: 100%; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      display: flex;
+      flex-direction: column;
+      user-select: none;
+    }
+
+    /* ── Title bar ── */
+    #title-bar {
+      height: 36px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 16px;
+      -webkit-app-region: drag;
+      flex-shrink: 0;
+      border-bottom: 1px solid var(--border);
+    }
+    #title-bar span { font-size: .8rem; color: var(--text-muted); }
+    #btn-close {
+      -webkit-app-region: no-drag;
+      background: none; border: none;
+      color: var(--text-muted); font-size: 1rem;
+      cursor: pointer; line-height: 1;
+      padding: 2px 6px; border-radius: 4px;
+    }
+    #btn-close:hover { background: #7f1d1d; color: #fca5a5; }
+
+    /* ── Layout ── */
+    #body { display: flex; flex: 1; overflow: hidden; }
+
+    /* ── Sidebar ── */
+    #sidebar {
+      width: 200px;
+      flex-shrink: 0;
+      border-right: 1px solid var(--border);
+      padding: 24px 0;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .step-item {
+      display: flex; align-items: center; gap: 12px;
+      padding: 10px 20px;
+      font-size: .85rem; color: var(--text-muted);
+      transition: color .15s;
+    }
+    .step-item.active { color: var(--text); }
+    .step-item.done   { color: var(--success); }
+    .step-item.err    { color: var(--error); }
+    .step-num {
+      width: 22px; height: 22px; border-radius: 50%;
+      border: 1px solid var(--border);
+      display: flex; align-items: center; justify-content: center;
+      font-size: .72rem; font-weight: 700; flex-shrink: 0;
+      color: var(--text-muted); transition: all .15s;
+    }
+    .step-item.active .step-num { border-color: var(--accent); color: var(--accent); }
+    .step-item.done   .step-num { border-color: var(--success); color: var(--success); background: #14532d22; }
+    .step-item.err    .step-num { border-color: var(--error);   color: var(--error); }
+
+    /* ── Content ── */
+    #content { flex: 1; padding: 32px 36px 24px; display: flex; flex-direction: column; overflow: hidden; }
+    .panel { display: none; flex-direction: column; flex: 1; }
+    .panel.active { display: flex; }
+    .panel h2 { font-size: 1.2rem; font-weight: 600; margin-bottom: 8px; }
+    .panel p  { font-size: .88rem; color: var(--text-muted); line-height: 1.6; margin-bottom: 16px; }
+
+    /* Status row */
+    .status-row {
+      display: flex; align-items: center; gap: 10px;
+      padding: 12px 16px; border-radius: 8px;
+      border: 1px solid var(--border); background: var(--surface);
+      font-size: .88rem; min-height: 48px;
+    }
+    .status-row.ok   { border-color: #166534; background: #14532d22; }
+    .status-row.fail { border-color: #991b1b; background: #7f1d1d22; }
+
+    /* Install log */
+    #install-log {
+      flex: 1; background: #0a0a0a;
+      border: 1px solid var(--border); border-radius: 8px;
+      padding: 12px; overflow-y: auto;
+      font-family: "Consolas", "SF Mono", monospace;
+      font-size: .78rem; color: #9ca3af;
+      white-space: pre-wrap; word-break: break-all;
+    }
+
+    /* API key inputs */
+    .field { display: flex; flex-direction: column; gap: 6px; margin-bottom: 16px; }
+    .field label { font-size: .82rem; color: var(--text-muted); }
+    .field input {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 8px; color: var(--text);
+      font-size: .88rem; padding: 10px 14px;
+      outline: none; font-family: "Consolas", monospace;
+    }
+    .field input:focus { border-color: var(--accent); }
+    .field .hint { font-size: .75rem; color: var(--text-muted); }
+    .field .hint a { color: var(--accent); cursor: pointer; text-decoration: underline; }
+
+    .key-status {
+      font-size: .8rem; padding: 8px 12px; border-radius: 6px;
+      border: 1px solid var(--border); min-height: 36px;
+      display: none; align-items: center; gap: 8px;
+    }
+    .key-status.ok   { border-color: #166534; background: #14532d22; color: var(--success); display: flex; }
+    .key-status.fail { border-color: #991b1b; background: #7f1d1d22; color: var(--error);   display: flex; }
+    .key-status.checking { border-color: var(--border); display: flex; }
+
+    /* Done panel */
+    #panel-done { align-items: center; justify-content: center; text-align: center; gap: 12px; }
+    #panel-done .checkmark { font-size: 3rem; }
+    #panel-done h2 { font-size: 1.4rem; }
+
+    /* ── Footer ── */
+    #footer {
+      padding: 16px 36px; display: flex;
+      justify-content: flex-end; gap: 10px;
+      border-top: 1px solid var(--border); flex-shrink: 0;
+    }
+    button {
+      padding: 8px 22px; border-radius: 8px;
+      font-size: .88rem; font-weight: 600; cursor: pointer; border: none;
+    }
+    #btn-back { background: var(--surface); color: var(--text-muted); border: 1px solid var(--border); }
+    #btn-back:hover:not(:disabled) { color: var(--text); }
+    #btn-next { background: var(--accent); color: #fff; }
+    #btn-next:hover:not(:disabled) { background: #2563eb; }
+    button:disabled { opacity: .4; cursor: not-allowed; }
+
+    code {
+      font-family: "Consolas", monospace;
+      font-size: .82em; background: #111;
+      border-radius: 3px; padding: 1px 5px;
+    }
+  </style>
+</head>
+<body>
+
+<div id="title-bar">
+  <span>Charles — Setup</span>
+  <button id="btn-close" title="Cancel and quit">✕</button>
+</div>
+
+<div id="body">
+  <nav id="sidebar">
+    <div class="step-item" id="nav-0"><div class="step-num">1</div>Welcome</div>
+    <div class="step-item" id="nav-1"><div class="step-num">2</div>Python</div>
+    <div class="step-item" id="nav-2"><div class="step-num">3</div>Dependencies</div>
+    <div class="step-item" id="nav-3"><div class="step-num">4</div>API Keys</div>
+    <div class="step-item" id="nav-4"><div class="step-num">5</div>Done</div>
+  </nav>
+
+  <main id="content">
+
+    <!-- Step 0: Welcome -->
+    <div class="panel" id="panel-0">
+      <h2>Welcome to Charles</h2>
+      <p>This wizard runs once and gets Charles set up on your machine. It should take about a minute.</p>
+      <p>Here's what will happen:</p>
+      <p style="color:var(--text); line-height:2.2;">
+        ① Verify Python 3.10+ is installed<br>
+        ② Install Python packages for the API and voice service<br>
+        ③ Save your API keys to <code>.env</code>
+      </p>
+    </div>
+
+    <!-- Step 1: Python -->
+    <div class="panel" id="panel-1">
+      <h2>Python Check</h2>
+      <p>Charles requires Python 3.10 or higher for the API and voice pipeline.</p>
+      <div class="status-row" id="python-status">
+        <span id="python-icon">⏳</span>
+        <span id="python-text">Checking…</span>
+      </div>
+    </div>
+
+    <!-- Step 2: Dependencies -->
+    <div class="panel" id="panel-2">
+      <h2>Install Dependencies</h2>
+      <p>Installing Python packages for the API and voice service. This may take a minute on first run.</p>
+      <div id="install-log">Waiting to start…</div>
+    </div>
+
+    <!-- Step 3: API Keys -->
+    <div class="panel" id="panel-3">
+      <h2>API Keys</h2>
+      <p>These keys are saved only to your local <code>.env</code> file and never leave your machine.</p>
+      <div class="field">
+        <label>OpenRouter API Key</label>
+        <input type="password" id="input-openrouter" placeholder="sk-or-v1-…" autocomplete="off" spellcheck="false" />
+        <span class="hint">Get one free at <a id="link-openrouter">openrouter.ai/keys</a></span>
+      </div>
+      <div class="field">
+        <label>Picovoice Access Key</label>
+        <input type="password" id="input-picovoice" placeholder="Your Picovoice access key" autocomplete="off" spellcheck="false" />
+        <span class="hint">Get one free at <a id="link-picovoice">console.picovoice.ai</a></span>
+      </div>
+      <div class="key-status" id="key-status"></div>
+    </div>
+
+    <!-- Step 4: Done -->
+    <div class="panel" id="panel-done">
+      <div class="checkmark">✅</div>
+      <h2>You're all set!</h2>
+      <p>Charles is ready. Click Launch to open the app.</p>
+    </div>
+
+  </main>
+</div>
+
+<div id="footer">
+  <button id="btn-back" style="display:none">Back</button>
+  <button id="btn-next">Get Started</button>
+</div>
+
+<script>
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+/** Set a two-part status row using safe textContent (no innerHTML). */
+function setStatusRow(icon, text, state) {
+  const $row  = document.getElementById('python-status')
+  const $icon = document.getElementById('python-icon')
+  const $text = document.getElementById('python-text')
+  $icon.textContent = icon
+  $text.textContent = text
+  $row.className = 'status-row ' + (state || '')
+}
+
+/** Set the key-status message safely. */
+function setKeyStatus(icon, message, state) {
+  const $ks = document.getElementById('key-status')
+  $ks.textContent = ''  // clear all children
+  const iconSpan = document.createElement('span')
+  iconSpan.textContent = icon
+  const msgSpan = document.createElement('span')
+  msgSpan.textContent = message
+  $ks.appendChild(iconSpan)
+  $ks.appendChild(msgSpan)
+  $ks.className = 'key-status ' + (state || '')
+}
+
+// ── State ──────────────────────────────────────────────────────────────────────
+const STEP_IDS = ['panel-0', 'panel-1', 'panel-2', 'panel-3', 'panel-done']
+let current    = 0
+let passed     = [false, false, false, false, false]
+let installing = false
+let cleanupLog = null
+
+const $next     = document.getElementById('btn-next')
+const $back     = document.getElementById('btn-back')
+const $navItems = [0,1,2,3,4].map(i => document.getElementById('nav-' + i))
+
+// ── Navigation ─────────────────────────────────────────────────────────────────
+function goTo(index) {
+  document.getElementById(STEP_IDS[current])?.classList.remove('active')
+  $navItems[current]?.classList.remove('active')
+  current = index
+  document.getElementById(STEP_IDS[current])?.classList.add('active')
+  $navItems[current]?.classList.add('active')
+  $back.style.display = (current > 0 && current < 4) ? 'inline' : 'none'
+  const isLast = current === STEP_IDS.length - 1
+  $next.textContent = isLast ? 'Launch Charles' : current === 0 ? 'Get Started' : 'Next'
+  $next.disabled = !passed[current] && !isLast
+  activateStep(current)
+}
+
+function markStep(index, ok) {
+  passed[index] = ok
+  $navItems[index].className = 'step-item ' + (ok ? 'done' : 'err')
+  if (index === current) $next.disabled = !ok
+}
+
+// ── Step side-effects ──────────────────────────────────────────────────────────
+async function activateStep(index) {
+  if (index === 0) { passed[0] = true; $next.disabled = false; }
+  if (index === 1) await runPythonCheck()
+  if (index === 2) await runInstall()
+}
+
+async function runPythonCheck() {
+  setStatusRow('⏳', 'Checking Python…', '')
+  $next.disabled = true
+  const r = await window.wizardAPI.checkPython()
+  if (r.ok) {
+    setStatusRow('✅', 'Python ' + r.version + ' — good to go', 'ok')
+    markStep(1, true)
+  } else {
+    setStatusRow('❌', r.error, 'fail')
+    markStep(1, false)
+  }
+}
+
+async function runInstall() {
+  if (installing) return
+  installing = true
+  $next.disabled = true
+  const $log = document.getElementById('install-log')
+  $log.textContent = ''
+  if (cleanupLog) { cleanupLog(); cleanupLog = null }
+  cleanupLog = window.wizardAPI.onInstallProgress(({ text }) => {
+    $log.textContent += text
+    $log.scrollTop = $log.scrollHeight
+  })
+  const r = await window.wizardAPI.installDeps()
+  installing = false
+  if (cleanupLog) { cleanupLog(); cleanupLog = null }
+  markStep(2, r.ok)
+}
+
+// ── Next / Back ────────────────────────────────────────────────────────────────
+$next.addEventListener('click', async () => {
+  if (current === STEP_IDS.length - 1) {
+    await window.wizardAPI.finish()
+    return
+  }
+
+  if (current === 3) {
+    const orKey  = document.getElementById('input-openrouter').value.trim()
+    const pvKey  = document.getElementById('input-picovoice').value.trim()
+    if (!orKey || !pvKey) {
+      setKeyStatus('⚠️', 'Both keys are required.', 'fail')
+      return
+    }
+    setKeyStatus('⏳', 'Validating…', 'checking')
+    $next.disabled = true
+    const r = await window.wizardAPI.validateKeys({ openrouterKey: orKey, picovoiceKey: pvKey })
+    if (!r.ok) {
+      setKeyStatus('❌', r.error, 'fail')
+      $next.disabled = false
+      return
+    }
+    await window.wizardAPI.saveKeys({ openrouterKey: orKey, picovoiceKey: pvKey })
+    setKeyStatus('✅', 'Keys saved', 'ok')
+    markStep(3, true)
+  }
+
+  goTo(current + 1)
+})
+
+$back.addEventListener('click', () => { if (current > 0) goTo(current - 1) })
+document.getElementById('btn-close').addEventListener('click', () => window.wizardAPI.close())
+
+// External links (open in browser, not Electron)
+document.getElementById('link-openrouter').addEventListener('click', () => {
+  window.open('https://openrouter.ai/keys')
+})
+document.getElementById('link-picovoice').addEventListener('click', () => {
+  window.open('https://console.picovoice.ai/')
+})
+
+// ── Boot ───────────────────────────────────────────────────────────────────────
+goTo(0)
+</script>
+
+</body>
+</html>

--- a/launcher/renderer/wizard.html
+++ b/launcher/renderer/wizard.html
@@ -312,6 +312,7 @@ async function activateStep(index) {
   if (index === 0) { passed[0] = true; $next.disabled = false; }
   if (index === 1) await runPythonCheck()
   if (index === 2) await runInstall()
+  if (index === 3) { passed[3] = true; $next.disabled = false; }
 }
 
 async function runPythonCheck() {

--- a/launcher/renderer/wizard.html
+++ b/launcher/renderer/wizard.html
@@ -205,20 +205,30 @@
       <div id="install-log">Waiting to start…</div>
     </div>
 
-    <!-- Step 3: API Keys -->
+    <!-- Step 3: Connect accounts -->
     <div class="panel" id="panel-3">
-      <h2>API Keys</h2>
-      <p>These keys are saved only to your local <code>.env</code> file and never leave your machine.</p>
+      <h2>Connect Accounts</h2>
+      <p>Charles needs two things: an AI provider and a wake word licence. Both are free.</p>
+
+      <!-- OpenRouter OAuth -->
       <div class="field">
-        <label>OpenRouter API Key</label>
-        <input type="password" id="input-openrouter" placeholder="sk-or-v1-…" autocomplete="off" spellcheck="false" />
-        <span class="hint">Get one free at <a id="link-openrouter">openrouter.ai/keys</a></span>
+        <label>AI Provider — OpenRouter</label>
+        <div id="or-connect-row" style="display:flex; align-items:center; gap:10px;">
+          <button id="btn-oauth" style="background:var(--accent);color:#fff;border:none;border-radius:8px;padding:9px 18px;font-size:.88rem;font-weight:600;cursor:pointer;">
+            Connect with OpenRouter
+          </button>
+          <span id="or-status" style="font-size:.82rem; color:var(--text-muted);">Opens your browser</span>
+        </div>
+        <span class="hint">Sign in with Google or GitHub — no key to copy/paste</span>
       </div>
+
+      <!-- Picovoice key -->
       <div class="field">
-        <label>Picovoice Access Key</label>
+        <label>Wake Word Licence — Picovoice</label>
         <input type="password" id="input-picovoice" placeholder="Your Picovoice access key" autocomplete="off" spellcheck="false" />
-        <span class="hint">Get one free at <a id="link-picovoice">console.picovoice.ai</a></span>
+        <span class="hint">Free key at <a id="link-picovoice">console.picovoice.ai</a> — needed so the "Hey Charles" SDK can run</span>
       </div>
+
       <div class="key-status" id="key-status"></div>
     </div>
 
@@ -269,6 +279,7 @@ let current    = 0
 let passed     = [false, false, false, false, false]
 let installing = false
 let cleanupLog = null
+let oauthKey   = null   // OpenRouter key received from OAuth flow
 
 const $next     = document.getElementById('btn-next')
 const $back     = document.getElementById('btn-back')
@@ -331,6 +342,28 @@ async function runInstall() {
   markStep(2, r.ok)
 }
 
+// ── OAuth button ───────────────────────────────────────────────────────────────
+document.getElementById('btn-oauth').addEventListener('click', async () => {
+  const $btn    = document.getElementById('btn-oauth')
+  const $status = document.getElementById('or-status')
+  $btn.disabled = true
+  $status.style.color = ''
+  $status.textContent = '⏳ Waiting for browser…'
+
+  const result = await window.wizardAPI.startOpenRouterOAuth()
+  if (result.ok) {
+    oauthKey = result.key
+    $btn.style.display = 'none'
+    $status.style.color = 'var(--success)'
+    $status.textContent = '✅ Connected'
+  } else {
+    oauthKey = null
+    $btn.disabled = false
+    $status.style.color = 'var(--error)'
+    $status.textContent = '❌ ' + result.error
+  }
+})
+
 // ── Next / Back ────────────────────────────────────────────────────────────────
 $next.addEventListener('click', async () => {
   if (current === STEP_IDS.length - 1) {
@@ -339,22 +372,29 @@ $next.addEventListener('click', async () => {
   }
 
   if (current === 3) {
-    const orKey  = document.getElementById('input-openrouter').value.trim()
-    const pvKey  = document.getElementById('input-picovoice').value.trim()
-    if (!orKey || !pvKey) {
-      setKeyStatus('⚠️', 'Both keys are required.', 'fail')
+    const pvKey = document.getElementById('input-picovoice').value.trim()
+
+    if (!oauthKey) {
+      setKeyStatus('⚠️', 'Please connect your OpenRouter account first.', 'fail')
       return
     }
-    setKeyStatus('⏳', 'Validating…', 'checking')
+    if (!pvKey) {
+      setKeyStatus('⚠️', 'Picovoice access key is required.', 'fail')
+      return
+    }
+
+    setKeyStatus('⏳', 'Validating Picovoice key…', 'checking')
     $next.disabled = true
-    const r = await window.wizardAPI.validateKeys({ openrouterKey: orKey, picovoiceKey: pvKey })
+
+    const r = await window.wizardAPI.validatePicovoice(pvKey)
     if (!r.ok) {
       setKeyStatus('❌', r.error, 'fail')
       $next.disabled = false
       return
     }
-    await window.wizardAPI.saveKeys({ openrouterKey: orKey, picovoiceKey: pvKey })
-    setKeyStatus('✅', 'Keys saved', 'ok')
+
+    await window.wizardAPI.saveKeys({ openrouterKey: oauthKey, picovoiceKey: pvKey })
+    setKeyStatus('✅', 'All set — keys saved', 'ok')
     markStep(3, true)
   }
 
@@ -364,10 +404,7 @@ $next.addEventListener('click', async () => {
 $back.addEventListener('click', () => { if (current > 0) goTo(current - 1) })
 document.getElementById('btn-close').addEventListener('click', () => window.wizardAPI.close())
 
-// External links (open in browser, not Electron)
-document.getElementById('link-openrouter').addEventListener('click', () => {
-  window.open('https://openrouter.ai/keys')
-})
+// External links
 document.getElementById('link-picovoice').addEventListener('click', () => {
   window.open('https://console.picovoice.ai/')
 })

--- a/launcher/wizard.js
+++ b/launcher/wizard.js
@@ -263,8 +263,51 @@ function _exchangeCodeForKey(code, verifier) {
 //     since this runs after Step 2), and adds a few seconds of wait time.
 //
 async function validatePicovoiceKey(picovoiceKey) {
-  // Replace this placeholder with your implementation
-  return { ok: true }
+  if (!picovoiceKey || !picovoiceKey.trim()) {
+    return { ok: false, error: 'Picovoice key cannot be empty.' }
+  }
+
+  return new Promise((resolve) => {
+    // Key is passed via environment variable — never injected into the script
+    // string — so quotes or special characters in the key can't break anything.
+    const script = [
+      'import pvporcupine, os',
+      'pv = pvporcupine.create(access_key=os.environ["PV_KEY"])',
+      'pv.delete()',
+    ].join('; ')
+
+    const proc = spawn('python', ['-c', script], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      env: { ...process.env, PV_KEY: picovoiceKey },
+    })
+
+    let stderr = ''
+    proc.stderr.on('data', d => { stderr += d })
+
+    // 10-second timeout — SDK init should be near-instant
+    const timer = setTimeout(() => {
+      proc.kill()
+      resolve({ ok: false, error: 'Validation timed out. Check your internet connection.' })
+    }, 10_000)
+
+    proc.on('exit', (code) => {
+      clearTimeout(timer)
+      if (code === 0) {
+        resolve({ ok: true })
+      } else {
+        // pvporcupine prints a descriptive error to stderr — surface it
+        const hint = stderr.includes('invalid') || stderr.includes('Invalid')
+          ? 'Key not recognised — double-check at console.picovoice.ai'
+          : 'Picovoice validation failed — check your key and internet connection.'
+        resolve({ ok: false, error: hint })
+      }
+    })
+
+    proc.on('error', () => {
+      clearTimeout(timer)
+      resolve({ ok: false, error: 'Could not run Python to validate key.' })
+    })
+  })
 }
 
 // ── Exports ───────────────────────────────────────────────────────────────────

--- a/launcher/wizard.js
+++ b/launcher/wizard.js
@@ -1,21 +1,22 @@
 /**
  * wizard.js — First-run setup wizard (BrowserWindow + IPC handlers).
  *
- * Called by main.js when no setup_complete flag exists.
  * Walks the user through:
  *   1. Python version check
  *   2. pip dependency install (api + voice requirements)
- *   3. API key entry + validation
+ *   3. Connect OpenRouter via OAuth + enter Picovoice key
  *   4. Writing .env and marking setup complete
  *
  * All IPC handlers are removed after finish() so they cannot
  * interfere with the main window's IPC after setup.
  */
 
-const { BrowserWindow, ipcMain, app } = require('electron')
+const { BrowserWindow, ipcMain, app, shell } = require('electron')
 const path    = require('path')
 const fs      = require('fs')
+const http    = require('http')
 const https   = require('https')
+const crypto  = require('crypto')
 const { spawn } = require('child_process')
 
 // ── Paths ─────────────────────────────────────────────────────────────────────
@@ -40,7 +41,6 @@ function createWizardWindow({ onComplete }) {
     },
   })
   wizardWindow.loadFile(path.join(__dirname, 'renderer', 'wizard.html'))
-
   _registerHandlers(onComplete)
 }
 
@@ -53,7 +53,7 @@ function _registerHandlers(onComplete) {
     const proc = spawn('python', ['--version'], { stdio: ['ignore', 'pipe', 'pipe'] })
     let out = ''
     proc.stdout.on('data', d => { out += d })
-    proc.stderr.on('data', d => { out += d })   // Python 2 prints to stderr
+    proc.stderr.on('data', d => { out += d })
     proc.on('error', () => resolve({ ok: false, error: 'Python not found. Download it from python.org.' }))
     proc.on('exit', (code) => {
       if (code !== 0) return resolve({ ok: false, error: 'Python not found. Download it from python.org.' })
@@ -94,17 +94,74 @@ function _registerHandlers(onComplete) {
     }
   })
 
-  // ── Step 3: validate API keys ─────────────────────────────────────────────
+  // ── Step 3a: OpenRouter OAuth (PKCE) ──────────────────────────────────────
   //
-  // TODO — implement validateKeys() below.
-  // This is called before saving to .env so the user gets feedback
-  // immediately if they paste a wrong key.
+  // Flow:
+  //   1. Generate a random PKCE verifier + SHA-256 challenge
+  //   2. Start a temporary localhost server to catch the redirect
+  //   3. Open the system browser to OpenRouter's auth page
+  //   4. Wait for the redirect (2-minute timeout)
+  //   5. Exchange the auth code for an API key
+  //   6. Return the key to the renderer — it is saved to .env on Next click
   //
-  ipcMain.handle('wizard:validate-keys', async (_, keys) => {
-    return validateKeys(keys)
+  ipcMain.handle('wizard:start-openrouter-oauth', async () => {
+    // 1. PKCE
+    const verifier  = crypto.randomBytes(32).toString('base64url')
+    const challenge = crypto.createHash('sha256').update(verifier).digest('base64url')
+
+    // 2. Local redirect server on a random available port
+    let resolveCode, rejectCode
+    const codePromise = new Promise((res, rej) => { resolveCode = res; rejectCode = rej })
+
+    const server = http.createServer((req, res) => {
+      const url  = new URL(req.url, 'http://localhost')
+      const code = url.searchParams.get('code')
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+      res.end(`<!DOCTYPE html><html><body style="font-family:sans-serif;
+        background:#0d0d0d;color:#e8e8e8;display:flex;align-items:center;
+        justify-content:center;height:100vh;margin:0;text-align:center">
+        <div><div style="font-size:3rem">✅</div>
+        <h2>Connected! You can close this tab.</h2></div></body></html>`)
+      server.close()
+      if (code) resolveCode(code)
+      else rejectCode(new Error('No authorization code in redirect'))
+    })
+
+    await new Promise((res, rej) => server.listen(0, '127.0.0.1', res).on('error', rej))
+    const port = server.address().port
+
+    // 3. Open browser
+    const callbackUrl = `http://127.0.0.1:${port}`
+    const authUrl = `https://openrouter.ai/auth?callback_url=${encodeURIComponent(callbackUrl)}`
+      + `&code_challenge=${challenge}&code_challenge_method=S256`
+    shell.openExternal(authUrl)
+
+    // 4. Wait for redirect (2-minute timeout)
+    const timer = setTimeout(() => {
+      server.close()
+      rejectCode(new Error('Authentication timed out. Please try again.'))
+    }, 120_000)
+
+    try {
+      const code = await codePromise
+      clearTimeout(timer)
+
+      // 5. Exchange code → API key
+      const key = await _exchangeCodeForKey(code, verifier)
+      return { ok: true, key }
+    } catch (err) {
+      clearTimeout(timer)
+      server.close()
+      return { ok: false, error: err.message }
+    }
   })
 
-  // ── Step 3: save keys to .env ─────────────────────────────────────────────
+  // ── Step 3b: validate Picovoice key ───────────────────────────────────────
+  ipcMain.handle('wizard:validate-picovoice', async (_, { picovoiceKey }) => {
+    return validatePicovoiceKey(picovoiceKey)
+  })
+
+  // ── Step 3c: save both keys to .env ───────────────────────────────────────
   ipcMain.handle('wizard:save-keys', (_, { openrouterKey, picovoiceKey }) => {
     const envPath = path.join(projectRoot, '.env')
     let content = fs.existsSync(envPath) ? fs.readFileSync(envPath, 'utf8') : ''
@@ -115,8 +172,8 @@ function _registerHandlers(onComplete) {
       return re.test(src) ? src.replace(re, line) : `${src}\n${line}`
     }
 
-    content = upsert(content, 'OPENROUTER_API_KEY',   openrouterKey)
-    content = upsert(content, 'PICOVOICE_ACCESS_KEY',  picovoiceKey)
+    content = upsert(content, 'OPENROUTER_API_KEY',  openrouterKey)
+    content = upsert(content, 'PICOVOICE_ACCESS_KEY', picovoiceKey)
     fs.writeFileSync(envPath, content.trim() + '\n', 'utf8')
     return { ok: true }
   })
@@ -125,33 +182,64 @@ function _registerHandlers(onComplete) {
   ipcMain.handle('wizard:finish', () => {
     fs.mkdirSync(path.dirname(setupFlagPath), { recursive: true })
     fs.writeFileSync(setupFlagPath, new Date().toISOString(), 'utf8')
-
     _removeHandlers()
     wizardWindow?.close()
     wizardWindow = null
     onComplete()
   })
 
-  // Window controls (wizard is frameless)
   ipcMain.handle('wizard:close', () => { app.quit() })
 }
 
 function _removeHandlers() {
   for (const ch of ['wizard:check-python', 'wizard:install-deps',
-                     'wizard:validate-keys', 'wizard:save-keys',
-                     'wizard:finish', 'wizard:close']) {
+                     'wizard:start-openrouter-oauth', 'wizard:validate-picovoice',
+                     'wizard:save-keys', 'wizard:finish', 'wizard:close']) {
     ipcMain.removeHandler(ch)
   }
 }
 
-// ── Key validation ────────────────────────────────────────────────────────────
+// ── OpenRouter code → key exchange ────────────────────────────────────────────
+
+function _exchangeCodeForKey(code, verifier) {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify({ code, code_verifier: verifier })
+    const req  = https.request({
+      hostname: 'openrouter.ai',
+      path:     '/api/v1/auth/keys',
+      method:   'POST',
+      headers:  {
+        'Content-Type':   'application/json',
+        'Content-Length': Buffer.byteLength(body),
+      },
+    }, (res) => {
+      let data = ''
+      res.on('data', d => { data += d })
+      res.on('end', () => {
+        try {
+          const json = JSON.parse(data)
+          if (json.key) resolve(json.key)
+          else reject(new Error(json.error || 'OpenRouter did not return a key'))
+        } catch {
+          reject(new Error('Invalid response from OpenRouter'))
+        }
+      })
+    })
+    req.on('error', reject)
+    req.write(body)
+    req.end()
+  })
+}
+
+// ── Picovoice key validation ──────────────────────────────────────────────────
 //
-// Validates both API keys before writing .env.
+// Called when the user enters their Picovoice access key.
+// The key is needed at runtime for the pvporcupine SDK licence check
+// (even though the .ppn wake word model files are already in the repo).
 //
 // Parameters
 // ----------
-// keys.openrouterKey  — the OpenRouter API key entered by the user
-// keys.picovoiceKey   — the Picovoice access key entered by the user
+// picovoiceKey  — string entered by the user
 //
 // Returns
 // -------
@@ -162,15 +250,19 @@ function _removeHandlers() {
 // TODO: implement this function.
 //
 // Things to consider:
-//   OpenRouter  — GET https://openrouter.ai/api/v1/auth/key with
-//                 Authorization: Bearer <key>. Returns 200 if valid,
-//                 401 if not. No tokens consumed.
-//   Picovoice   — No public REST health-check endpoint. Options:
-//                 (a) just verify it's non-empty and ~32 chars
-//                 (b) spawn `python -c "import pvporcupine; pvporcupine.create(access_key='...')"
-//                     and check exit code (slower but definitive)
+//   Option A — format check only (fast, ~0ms):
+//     Picovoice keys are long base64 strings, typically 128–512 chars.
+//     Reject if empty or clearly too short, accept otherwise.
+//     Downside: a valid-looking but revoked key won't be caught until
+//     the user tries to use voice features.
 //
-async function validateKeys({ openrouterKey, picovoiceKey }) {
+//   Option B — live SDK check (slow, ~3s):
+//     Spawn: python -c "import pvporcupine; pvporcupine.create(access_key='<key>').delete()"
+//     Exit code 0 = key is valid and the SDK accepted it.
+//     Downside: requires pvporcupine to already be installed (it will be,
+//     since this runs after Step 2), and adds a few seconds of wait time.
+//
+async function validatePicovoiceKey(picovoiceKey) {
   // Replace this placeholder with your implementation
   return { ok: true }
 }

--- a/launcher/wizard.js
+++ b/launcher/wizard.js
@@ -109,7 +109,12 @@ function _registerHandlers(onComplete) {
     const verifier  = crypto.randomBytes(32).toString('base64url')
     const challenge = crypto.createHash('sha256').update(verifier).digest('base64url')
 
-    // 2. Local redirect server on a random available port
+    // 2. Local redirect server.
+    //
+    // Use a fixed port so the callback_url is stable across auth attempts.
+    // OpenRouter keys its app registration to the callback_url — a different
+    // port each time looks like a new app and causes a 409 conflict.
+    // Ports 44888–44890 are Charles-specific; we try each in order.
     let resolveCode, rejectCode
     const codePromise = new Promise((res, rej) => { resolveCode = res; rejectCode = rej })
 
@@ -127,11 +132,23 @@ function _registerHandlers(onComplete) {
       else rejectCode(new Error('No authorization code in redirect'))
     })
 
-    await new Promise((res, rej) => server.listen(0, '127.0.0.1', res).on('error', rej))
-    const port = server.address().port
+    const PREFERRED_PORTS = [44888, 44889, 44890]
+    const port = await new Promise((res, rej) => {
+      let i = 0
+      const tryNext = () => {
+        if (i >= PREFERRED_PORTS.length) return rej(new Error('All callback ports are in use. Free port 44888–44890 and try again.'))
+        const p = PREFERRED_PORTS[i++]
+        server.once('error', (err) => {
+          if (err.code === 'EADDRINUSE') tryNext()
+          else rej(err)
+        })
+        server.listen(p, 'localhost', () => res(p))
+      }
+      tryNext()
+    })
 
     // 3. Open browser
-    const callbackUrl = `http://127.0.0.1:${port}`
+    const callbackUrl = `http://localhost:${port}`
     const authUrl = `https://openrouter.ai/auth?callback_url=${encodeURIComponent(callbackUrl)}`
       + `&code_challenge=${challenge}&code_challenge_method=S256`
     shell.openExternal(authUrl)

--- a/launcher/wizard.js
+++ b/launcher/wizard.js
@@ -189,12 +189,19 @@ function _registerHandlers(onComplete) {
   })
 
   ipcMain.handle('wizard:close', () => { app.quit() })
+
+  // Utility: open a URL in the system browser from renderer code
+  ipcMain.handle('wizard:open-external', (_, url) => {
+    const allowed = ['https://console.picovoice.ai/', 'https://openrouter.ai/']
+    if (allowed.some(prefix => url.startsWith(prefix))) shell.openExternal(url)
+  })
 }
 
 function _removeHandlers() {
   for (const ch of ['wizard:check-python', 'wizard:install-deps',
                      'wizard:start-openrouter-oauth', 'wizard:validate-picovoice',
-                     'wizard:save-keys', 'wizard:finish', 'wizard:close']) {
+                     'wizard:save-keys', 'wizard:finish', 'wizard:close',
+                     'wizard:open-external']) {
     ipcMain.removeHandler(ch)
   }
 }

--- a/launcher/wizard.js
+++ b/launcher/wizard.js
@@ -182,7 +182,7 @@ async function validatePicovoiceKey(picovoiceKey) {
     // string — so quotes or special characters in the key can't break anything.
     const script = [
       'import pvporcupine, os',
-      'pv = pvporcupine.create(access_key=os.environ["PV_KEY"])',
+      'pv = pvporcupine.create(access_key=os.environ["PV_KEY"], keywords=["porcupine"])',
       'pv.delete()',
     ].join('; ')
 

--- a/launcher/wizard.js
+++ b/launcher/wizard.js
@@ -209,7 +209,7 @@ function _registerHandlers(onComplete) {
 
   // Utility: open a URL in the system browser from renderer code
   ipcMain.handle('wizard:open-external', (_, url) => {
-    const allowed = ['https://console.picovoice.ai/', 'https://openrouter.ai/']
+    const allowed = ['https://console.picovoice.ai/', 'https://openrouter.ai/keys', 'https://openrouter.ai/auth']
     if (allowed.some(prefix => url.startsWith(prefix))) shell.openExternal(url)
   })
 }

--- a/launcher/wizard.js
+++ b/launcher/wizard.js
@@ -14,9 +14,6 @@
 const { BrowserWindow, ipcMain, app, shell } = require('electron')
 const path    = require('path')
 const fs      = require('fs')
-const http    = require('http')
-const https   = require('https')
-const crypto  = require('crypto')
 const { spawn } = require('child_process')
 
 // ── Paths ─────────────────────────────────────────────────────────────────────
@@ -94,85 +91,6 @@ function _registerHandlers(onComplete) {
     }
   })
 
-  // ── Step 3a: OpenRouter OAuth (PKCE) ──────────────────────────────────────
-  //
-  // Flow:
-  //   1. Generate a random PKCE verifier + SHA-256 challenge
-  //   2. Start a temporary localhost server to catch the redirect
-  //   3. Open the system browser to OpenRouter's auth page
-  //   4. Wait for the redirect (2-minute timeout)
-  //   5. Exchange the auth code for an API key
-  //   6. Return the key to the renderer — it is saved to .env on Next click
-  //
-  ipcMain.handle('wizard:start-openrouter-oauth', async () => {
-    // 1. PKCE
-    const verifier  = crypto.randomBytes(32).toString('base64url')
-    const challenge = crypto.createHash('sha256').update(verifier).digest('base64url')
-
-    // 2. Local redirect server.
-    //
-    // Use a fixed port so the callback_url is stable across auth attempts.
-    // OpenRouter keys its app registration to the callback_url — a different
-    // port each time looks like a new app and causes a 409 conflict.
-    // Ports 44888–44890 are Charles-specific; we try each in order.
-    let resolveCode, rejectCode
-    const codePromise = new Promise((res, rej) => { resolveCode = res; rejectCode = rej })
-
-    const server = http.createServer((req, res) => {
-      const url  = new URL(req.url, 'http://localhost')
-      const code = url.searchParams.get('code')
-      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
-      res.end(`<!DOCTYPE html><html><body style="font-family:sans-serif;
-        background:#0d0d0d;color:#e8e8e8;display:flex;align-items:center;
-        justify-content:center;height:100vh;margin:0;text-align:center">
-        <div><div style="font-size:3rem">✅</div>
-        <h2>Connected! You can close this tab.</h2></div></body></html>`)
-      server.close()
-      if (code) resolveCode(code)
-      else rejectCode(new Error('No authorization code in redirect'))
-    })
-
-    const PREFERRED_PORTS = [44888, 44889, 44890]
-    const port = await new Promise((res, rej) => {
-      let i = 0
-      const tryNext = () => {
-        if (i >= PREFERRED_PORTS.length) return rej(new Error('All callback ports are in use. Free port 44888–44890 and try again.'))
-        const p = PREFERRED_PORTS[i++]
-        server.once('error', (err) => {
-          if (err.code === 'EADDRINUSE') tryNext()
-          else rej(err)
-        })
-        server.listen(p, 'localhost', () => res(p))
-      }
-      tryNext()
-    })
-
-    // 3. Open browser
-    const callbackUrl = `http://localhost:${port}`
-    const authUrl = `https://openrouter.ai/auth?callback_url=${encodeURIComponent(callbackUrl)}`
-      + `&code_challenge=${challenge}&code_challenge_method=S256`
-    shell.openExternal(authUrl)
-
-    // 4. Wait for redirect (2-minute timeout)
-    const timer = setTimeout(() => {
-      server.close()
-      rejectCode(new Error('Authentication timed out. Please try again.'))
-    }, 120_000)
-
-    try {
-      const code = await codePromise
-      clearTimeout(timer)
-
-      // 5. Exchange code → API key
-      const key = await _exchangeCodeForKey(code, verifier)
-      return { ok: true, key }
-    } catch (err) {
-      clearTimeout(timer)
-      server.close()
-      return { ok: false, error: err.message }
-    }
-  })
-
   // ── Step 3b: validate Picovoice key ───────────────────────────────────────
   ipcMain.handle('wizard:validate-picovoice', async (_, { picovoiceKey }) => {
     return validatePicovoiceKey(picovoiceKey)
@@ -209,50 +127,18 @@ function _registerHandlers(onComplete) {
 
   // Utility: open a URL in the system browser from renderer code
   ipcMain.handle('wizard:open-external', (_, url) => {
-    const allowed = ['https://console.picovoice.ai/', 'https://openrouter.ai/keys', 'https://openrouter.ai/auth']
+    const allowed = ['https://console.picovoice.ai/', 'https://openrouter.ai/keys']
     if (allowed.some(prefix => url.startsWith(prefix))) shell.openExternal(url)
   })
 }
 
 function _removeHandlers() {
   for (const ch of ['wizard:check-python', 'wizard:install-deps',
-                     'wizard:start-openrouter-oauth', 'wizard:validate-picovoice',
+                     'wizard:validate-picovoice',
                      'wizard:save-keys', 'wizard:finish', 'wizard:close',
                      'wizard:open-external']) {
     ipcMain.removeHandler(ch)
   }
-}
-
-// ── OpenRouter code → key exchange ────────────────────────────────────────────
-
-function _exchangeCodeForKey(code, verifier) {
-  return new Promise((resolve, reject) => {
-    const body = JSON.stringify({ code, code_verifier: verifier })
-    const req  = https.request({
-      hostname: 'openrouter.ai',
-      path:     '/api/v1/auth/keys',
-      method:   'POST',
-      headers:  {
-        'Content-Type':   'application/json',
-        'Content-Length': Buffer.byteLength(body),
-      },
-    }, (res) => {
-      let data = ''
-      res.on('data', d => { data += d })
-      res.on('end', () => {
-        try {
-          const json = JSON.parse(data)
-          if (json.key) resolve(json.key)
-          else reject(new Error(json.error || 'OpenRouter did not return a key'))
-        } catch {
-          reject(new Error('Invalid response from OpenRouter'))
-        }
-      })
-    })
-    req.on('error', reject)
-    req.write(body)
-    req.end()
-  })
 }
 
 // ── Picovoice key validation ──────────────────────────────────────────────────

--- a/launcher/wizard.js
+++ b/launcher/wizard.js
@@ -1,0 +1,180 @@
+/**
+ * wizard.js — First-run setup wizard (BrowserWindow + IPC handlers).
+ *
+ * Called by main.js when no setup_complete flag exists.
+ * Walks the user through:
+ *   1. Python version check
+ *   2. pip dependency install (api + voice requirements)
+ *   3. API key entry + validation
+ *   4. Writing .env and marking setup complete
+ *
+ * All IPC handlers are removed after finish() so they cannot
+ * interfere with the main window's IPC after setup.
+ */
+
+const { BrowserWindow, ipcMain, app } = require('electron')
+const path    = require('path')
+const fs      = require('fs')
+const https   = require('https')
+const { spawn } = require('child_process')
+
+// ── Paths ─────────────────────────────────────────────────────────────────────
+
+const projectRoot   = path.join(__dirname, '..')
+const setupFlagPath = path.join(app.getPath('userData'), 'setup_complete')
+
+// ── Window ────────────────────────────────────────────────────────────────────
+
+let wizardWindow = null
+
+function createWizardWindow({ onComplete }) {
+  wizardWindow = new BrowserWindow({
+    width: 700, height: 540,
+    frame: false,
+    resizable: false,
+    backgroundColor: '#0d0d0d',
+    webPreferences: {
+      preload: path.join(__dirname, 'preload-wizard.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  })
+  wizardWindow.loadFile(path.join(__dirname, 'renderer', 'wizard.html'))
+
+  _registerHandlers(onComplete)
+}
+
+// ── IPC handlers ──────────────────────────────────────────────────────────────
+
+function _registerHandlers(onComplete) {
+
+  // ── Step 1: Python check ──────────────────────────────────────────────────
+  ipcMain.handle('wizard:check-python', () => new Promise((resolve) => {
+    const proc = spawn('python', ['--version'], { stdio: ['ignore', 'pipe', 'pipe'] })
+    let out = ''
+    proc.stdout.on('data', d => { out += d })
+    proc.stderr.on('data', d => { out += d })   // Python 2 prints to stderr
+    proc.on('error', () => resolve({ ok: false, error: 'Python not found. Download it from python.org.' }))
+    proc.on('exit', (code) => {
+      if (code !== 0) return resolve({ ok: false, error: 'Python not found. Download it from python.org.' })
+      const match = out.trim().match(/Python (\d+)\.(\d+)\.(\d+)/)
+      if (!match) return resolve({ ok: false, error: `Unexpected output: ${out.trim()}` })
+      const [, major, minor, patch] = match.map(Number)
+      const version = `${major}.${minor}.${patch}`
+      if (major < 3 || (major === 3 && minor < 10)) {
+        return resolve({ ok: false, version, error: `Python ${version} found but 3.10+ is required.` })
+      }
+      resolve({ ok: true, version })
+    })
+  }))
+
+  // ── Step 2: pip install (streams progress events to renderer) ─────────────
+  ipcMain.handle('wizard:install-deps', async () => {
+    const send = (text) => wizardWindow?.webContents.send('wizard:install-progress', { text })
+
+    const runPip = (label, reqFile) => new Promise((resolve, reject) => {
+      send(`\n▶  ${label}\n`)
+      const proc = spawn('python', ['-m', 'pip', 'install', '-r', reqFile, '--progress-bar', 'off'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      proc.stdout.on('data', d => send(d.toString()))
+      proc.stderr.on('data', d => send(d.toString()))
+      proc.on('error', reject)
+      proc.on('exit', code => code === 0 ? resolve() : reject(new Error(`pip exited with code ${code}`)))
+    })
+
+    try {
+      await runPip('Installing API dependencies…',   path.join(projectRoot, 'api',   'requirements.txt'))
+      await runPip('Installing voice dependencies…', path.join(projectRoot, 'voice', 'requirements.txt'))
+      send('\n✓  All dependencies installed successfully.\n')
+      return { ok: true }
+    } catch (err) {
+      send(`\n✗  Error: ${err.message}\n`)
+      return { ok: false, error: err.message }
+    }
+  })
+
+  // ── Step 3: validate API keys ─────────────────────────────────────────────
+  //
+  // TODO — implement validateKeys() below.
+  // This is called before saving to .env so the user gets feedback
+  // immediately if they paste a wrong key.
+  //
+  ipcMain.handle('wizard:validate-keys', async (_, keys) => {
+    return validateKeys(keys)
+  })
+
+  // ── Step 3: save keys to .env ─────────────────────────────────────────────
+  ipcMain.handle('wizard:save-keys', (_, { openrouterKey, picovoiceKey }) => {
+    const envPath = path.join(projectRoot, '.env')
+    let content = fs.existsSync(envPath) ? fs.readFileSync(envPath, 'utf8') : ''
+
+    const upsert = (src, key, value) => {
+      const re = new RegExp(`^${key}=.*$`, 'm')
+      const line = `${key}=${value}`
+      return re.test(src) ? src.replace(re, line) : `${src}\n${line}`
+    }
+
+    content = upsert(content, 'OPENROUTER_API_KEY',   openrouterKey)
+    content = upsert(content, 'PICOVOICE_ACCESS_KEY',  picovoiceKey)
+    fs.writeFileSync(envPath, content.trim() + '\n', 'utf8')
+    return { ok: true }
+  })
+
+  // ── Step 4: mark setup complete and launch main window ────────────────────
+  ipcMain.handle('wizard:finish', () => {
+    fs.mkdirSync(path.dirname(setupFlagPath), { recursive: true })
+    fs.writeFileSync(setupFlagPath, new Date().toISOString(), 'utf8')
+
+    _removeHandlers()
+    wizardWindow?.close()
+    wizardWindow = null
+    onComplete()
+  })
+
+  // Window controls (wizard is frameless)
+  ipcMain.handle('wizard:close', () => { app.quit() })
+}
+
+function _removeHandlers() {
+  for (const ch of ['wizard:check-python', 'wizard:install-deps',
+                     'wizard:validate-keys', 'wizard:save-keys',
+                     'wizard:finish', 'wizard:close']) {
+    ipcMain.removeHandler(ch)
+  }
+}
+
+// ── Key validation ────────────────────────────────────────────────────────────
+//
+// Validates both API keys before writing .env.
+//
+// Parameters
+// ----------
+// keys.openrouterKey  — the OpenRouter API key entered by the user
+// keys.picovoiceKey   — the Picovoice access key entered by the user
+//
+// Returns
+// -------
+// { ok: true }
+//   or
+// { ok: false, error: 'human-readable message shown in the wizard UI' }
+//
+// TODO: implement this function.
+//
+// Things to consider:
+//   OpenRouter  — GET https://openrouter.ai/api/v1/auth/key with
+//                 Authorization: Bearer <key>. Returns 200 if valid,
+//                 401 if not. No tokens consumed.
+//   Picovoice   — No public REST health-check endpoint. Options:
+//                 (a) just verify it's non-empty and ~32 chars
+//                 (b) spawn `python -c "import pvporcupine; pvporcupine.create(access_key='...')"
+//                     and check exit code (slower but definitive)
+//
+async function validateKeys({ openrouterKey, picovoiceKey }) {
+  // Replace this placeholder with your implementation
+  return { ok: true }
+}
+
+// ── Exports ───────────────────────────────────────────────────────────────────
+
+module.exports = { createWizardWindow, setupFlagPath }


### PR DESCRIPTION
## Summary

- First-run Electron GUI wizard (5 steps: Welcome → Python check → pip install → API keys → Done)
- OpenRouter API key + Picovoice key entry with live SDK validation
- Hotswappable model selector dropdown via `GET /models` + `GET/PUT /settings/model`
- Re-run Setup option in tray menu
- Single instance lock — second launch focuses existing window
- Security hardening: API bound to 127.0.0.1, tightened CORS/CSP

## Test plan

- [ ] Fresh install: delete `%AppData%\charles\setup_complete`, launch app, complete wizard
- [ ] Re-run Setup: right-click tray → Re-run Setup, confirm wizard reopens
- [ ] Single instance: launch with app already running, confirm window focuses instead of new instance
- [ ] Model selector: dropdown populates with OpenRouter models, changing selection persists across messages
- [ ] Second launch while running: `npm start` exits immediately, existing window raises

🤖 Generated with [Claude Code](https://claude.com/claude-code)