### PR TITLE
fix: Whisper hallucination, UTF-8 crash, close dialog, bubble spacing, timeouts

### DIFF
--- a/launcher/main.js
+++ b/launcher/main.js
@@ -210,6 +210,7 @@ function registerIPC() {
   })
   ipcMain.handle('minimize-window', () => mainWindow?.minimize())
   ipcMain.handle('close-window',    () => mainWindow?.close())
+  ipcMain.handle('quit-app',        () => { app.isQuiting = true; stopAll(); app.quit() })
 }
 
 // ── App lifecycle ─────────────────────────────────────────────────────────────

--- a/launcher/preload.js
+++ b/launcher/preload.js
@@ -6,6 +6,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   interrupt:   () => ipcRenderer.invoke('interrupt-voice'),
   minimize:    () => ipcRenderer.invoke('minimize-window'),
   closeWindow: () => ipcRenderer.invoke('close-window'),
+  quitApp:     () => ipcRenderer.invoke('quit-app'),
   onStatusUpdate: (cb) => {
     const listener = (_e, d) => cb(d)
     ipcRenderer.on('status-update', listener)

--- a/launcher/renderer/index.html
+++ b/launcher/renderer/index.html
@@ -62,10 +62,10 @@
       padding: 20px 0;
       display: flex;
       flex-direction: column;
-      gap: 2px;
+      gap: 20px;
     }
 
-    .turn { display: flex; flex-direction: column; gap: 0; }
+    .turn { display: flex; flex-direction: column; gap: 8px; }
 
     .bubble {
       max-width: min(680px, 90%);
@@ -151,6 +151,38 @@
       align-items: center;
       gap: 6px;
     }
+
+    /* ── Close dialog overlay ── */
+    #close-overlay {
+      display: none;
+      position: fixed; inset: 0;
+      background: rgba(0,0,0,0.55);
+      z-index: 100;
+      align-items: center;
+      justify-content: center;
+    }
+    #close-overlay.visible { display: flex; }
+    #close-dialog {
+      background: #1a1a1a;
+      border: 1px solid #2a2a2a;
+      border-radius: 12px;
+      padding: 24px 28px;
+      width: 300px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    #close-dialog h3 { font-size: .95rem; font-weight: 600; margin: 0; }
+    #close-dialog p  { font-size: .82rem; color: var(--text-muted); margin: 0; line-height: 1.5; }
+    .close-dialog-btns { display: flex; flex-direction: column; gap: 8px; margin-top: 4px; }
+    .close-dialog-btns button {
+      width: 100%; padding: 9px 0; border-radius: 8px;
+      font-size: .85rem; font-weight: 600; cursor: pointer; border: none;
+    }
+    #close-btn-tray { background: var(--accent); color: #fff; }
+    #close-btn-tray:hover { background: #2563eb; }
+    #close-btn-quit { background: #1f2937; color: #f87171; border: 1px solid #374151 !important; }
+    #close-btn-quit:hover { background: #7f1d1d; border-color: #991b1b !important; }
 
     /* ── Input bar ── */
     #input-bar {
@@ -281,6 +313,18 @@
 <div id="input-bar">
   <textarea id="msg-input" rows="1" placeholder="Message Charles…"></textarea>
   <button id="send-btn">Send</button>
+</div>
+
+<!-- Close dialog -->
+<div id="close-overlay">
+  <div id="close-dialog">
+    <h3>Close Charles?</h3>
+    <p>Minimize to the system tray to keep Charles running in the background, or quit to stop all services.</p>
+    <div class="close-dialog-btns">
+      <button id="close-btn-tray">Minimize to Tray</button>
+      <button id="close-btn-quit">Quit Charles</button>
+    </div>
+  </div>
 </div>
 
 <script>
@@ -630,7 +674,23 @@ $modelSelect.addEventListener('change', () => {
 
 // Window chrome controls (frameless window has no native buttons)
 document.getElementById('btn-minimize').addEventListener('click', () => window.electronAPI.minimize());
-document.getElementById('btn-close').addEventListener('click',    () => window.electronAPI.closeWindow());
+
+// Close button — show dialog instead of closing immediately
+const $closeOverlay = document.getElementById('close-overlay');
+document.getElementById('btn-close').addEventListener('click', () => {
+  $closeOverlay.classList.add('visible');
+});
+// Click outside the dialog card → dismiss
+$closeOverlay.addEventListener('click', (e) => {
+  if (e.target === $closeOverlay) $closeOverlay.classList.remove('visible');
+});
+document.getElementById('close-btn-tray').addEventListener('click', () => {
+  $closeOverlay.classList.remove('visible');
+  window.electronAPI.closeWindow();
+});
+document.getElementById('close-btn-quit').addEventListener('click', () => {
+  window.electronAPI.quitApp();
+});
 
 const cleanupStatus = window.electronAPI.onStatusUpdate(({ state, message }) => {
   setStatus(state, message);

--- a/voice/main.py
+++ b/voice/main.py
@@ -38,6 +38,10 @@ from dotenv import load_dotenv
 # ── Load .env before importing our modules (they read env at import time) ──────
 load_dotenv()
 
+# ── Ensure stdout is UTF-8 on Windows (default cp1252 can't encode Whisper output) ──
+if hasattr(sys.stdout, 'reconfigure'):
+    sys.stdout.reconfigure(encoding='utf-8')
+
 import api_client
 import audio
 import stt

--- a/voice/stt.py
+++ b/voice/stt.py
@@ -86,6 +86,15 @@ def transcribe(audio: np.ndarray) -> str:
     text: str = result.get("text", "").strip()
     elapsed = time.perf_counter() - t0
     logger.info("Transcription (%.2f s): %r", elapsed, text)
+
+    # Whisper hallucinates multilingual garbage on near-silence — discard it.
+    # If more than 30% of characters are non-ASCII the output is not real speech.
+    if text:
+        non_ascii = sum(1 for c in text if ord(c) > 127)
+        if non_ascii / len(text) > 0.30:
+            logger.info("Transcription discarded — likely hallucination (%.0f%% non-ASCII)", 100 * non_ascii / len(text))
+            return ""
+
     return text
 
 


### PR DESCRIPTION
## Summary

- **Whisper hallucination filter** — discards transcriptions where >30% of characters are non-ASCII (garbage output Whisper produces on near-silence)
- **UTF-8 stdout fix** — prevents `UnicodeEncodeError` crash on Windows when non-Latin characters reach `print()`
- **Close dialog** — clicking ✕ now shows "Minimize to Tray" / "Quit Charles" options; click outside to dismiss
- **Chat bubble spacing** — turn gap 2px → 20px, intra-turn gap 0 → 8px
- **2-minute timeout** — aligned OpenRouter, voice client, and GUI fetch to 120s; GUI shows clear timeout message instead of stuck thinking bubble

## Test plan
- [ ] Say something quiet/ambiguous after wake word — should get "Sorry, I didn't catch that", not a crash
- [ ] Click ✕ — dialog appears with two options
- [ ] Click outside dialog — dismisses without action
- [ ] Minimize to Tray — hides window, Charles keeps running
- [ ] Quit Charles — stops all services and exits
- [ ] Chat bubbles have visible spacing between turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)